### PR TITLE
refactor: remove bang from startinsert command

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -89,6 +89,7 @@ end
 ---Terminal buffer autocommands
 ---@param term Terminal
 local function setup_buffer_autocommands(term)
+  local conf = config.get()
   local commands = {
     {
       "TermClose",
@@ -96,6 +97,15 @@ local function setup_buffer_autocommands(term)
       fmt('lua require"toggleterm.terminal".delete(%d)', term.id),
     },
   }
+
+  if conf.start_in_insert then
+    vim.cmd("startinsert")
+    table.insert(commands, {
+      "BufEnter",
+      fmt("<buffer=%d>", term.bufnr),
+      "startinsert",
+    })
+  end
 
   utils.create_augroups({ ["ToggleTerm" .. term.bufnr] = commands })
 end
@@ -285,8 +295,6 @@ end
 ---@param term table
 local function opener(size, term)
   local direction = term.direction
-  local conf = config.get()
-
   if term:is_split() then
     ui.open_split(size, term)
   elseif direction == "window" then
@@ -298,11 +306,6 @@ local function opener(size, term)
   else
     error("Invalid terminal direction")
   end
-
-  if conf.start_in_insert then
-    vim.cmd('startinsert!')
-  end
-
 end
 
 ---Open a terminal window

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -89,7 +89,6 @@ end
 ---Terminal buffer autocommands
 ---@param term Terminal
 local function setup_buffer_autocommands(term)
-  local conf = config.get()
   local commands = {
     {
       "TermClose",
@@ -97,15 +96,6 @@ local function setup_buffer_autocommands(term)
       fmt('lua require"toggleterm.terminal".delete(%d)', term.id),
     },
   }
-
-  if conf.start_in_insert then
-    vim.cmd("startinsert!")
-    table.insert(commands, {
-      "BufEnter",
-      fmt("<buffer=%d>", term.bufnr),
-      "startinsert!",
-    })
-  end
 
   utils.create_augroups({ ["ToggleTerm" .. term.bufnr] = commands })
 end
@@ -295,6 +285,8 @@ end
 ---@param term table
 local function opener(size, term)
   local direction = term.direction
+  local conf = config.get()
+
   if term:is_split() then
     ui.open_split(size, term)
   elseif direction == "window" then
@@ -306,6 +298,11 @@ local function opener(size, term)
   else
     error("Invalid terminal direction")
   end
+
+  if conf.start_in_insert then
+    vim.cmd('startinsert!')
+  end
+
 end
 
 ---Open a terminal window


### PR DESCRIPTION
When using a floating terminal, opening and closing under certain scenarios results in a shift in the buffer's contents to the left.
To reproduce open a terminal with "float" direction, run `lazygit` and toggle the term a couple of times. The terminal's content will shift.

The problem may be an issue with using `startinsert!` as an autocmd, refactoring it to be executed once the terminal is open as a regular conditional fixes the issue.

If the root cause of the problem is related to other things let me know, but I believe this solution shouldn't sacrifice performance or code consistency.