### PR TITLE
feat: support both cmd and powershell(pwsh) for windows

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -10,8 +10,9 @@ local fmt = string.format
 local fn = vim.fn
 
 local is_windows = fn.has("win32") == 1
-local command_sep = is_windows and "&" or ";"
-local comment_sep = is_windows and "::" or "#"
+local is_cmd = string.find(vim.o.shell, 'cmd')
+local command_sep = is_windows and is_cmd and "&" or ";"
+local comment_sep = is_windows and is_cmd and "::" or "#"
 
 ---@type Terminal[]
 local terminals = {}


### PR DESCRIPTION
Windows system has two shell, Cmd and PowerShell (pwsh). 

Cmd can uses :: to comment, and  & to split. 
Powershell uses the # to comment, and ; to split, similar as bash. 

Toggleterm now distinguishes between linux and windows , but not deal with the cmd and powershell under the windows environment, resulting in the following error when using powershell:
![1](https://user-images.githubusercontent.com/22053969/133870962-b053effe-be2e-4b48-a03d-65afb1670f1d.png)

This PR distinguishes the difference between cmd and powershell in windows environment to use the correct separator in powershell.