### PR TITLE
feat!: allow global config of on_exit(), on_stdout(), on_stderr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ require("toggleterm").setup{
   open_mapping = [[<c-\>]],
   on_open = fun(t: Terminal), -- function to run when the terminal opens
   on_close = fun(t: Terminal), -- function to run when the terminal closes
+  on_stdout = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stdout
+  on_stderr = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stderr
+  on_exit = fun(t: Terminal, job: number, exit_code: number, name: string) -- function to run when terminal process exits
   hide_numbers = true, -- hide the number column in toggleterm buffers
   shade_filetypes = {},
   shade_terminals = true,
@@ -302,9 +305,9 @@ Terminal:new {
   on_open = fun(t: Terminal) -- function to run when the terminal opens
   on_close = fun(t: Terminal) -- function to run when the terminal closes
   -- callbacks for processing the output
-  on_stdout = fun(job: number, exit_code: number, type: string)
-  on_stderr = fun(job: number, data: string[], name: string)
-  on_exit = fun(job: number, data: string[], name: string)
+  on_stdout = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stdout
+  on_stderr = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stderr
+  on_exit = fun(t: Terminal, job: number, exit_code: number, name: string) -- function to run when terminal process exits
 }
 ```
 

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -113,6 +113,9 @@ the terminals will be discarded when closed.
       open_mapping = [[<c-\>]],
       on_open = fun(t: Terminal), -- function to run when the terminal opens
       on_close = fun(t: Terminal), -- function to run when the terminal closes
+      on_stdout = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stdout
+      on_stderr = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stderr
+      on_exit = fun(t: Terminal, job: number, exit_code: number, name: string) -- function to run when terminal process exits
       hide_numbers = true, -- hide the number column in toggleterm buffers
       shade_filetypes = {},
       shade_terminals = true,
@@ -309,9 +312,9 @@ Each terminal can take the following arguments:
       on_open = fun(t: Terminal) -- function to run when the terminal opens
       on_close = fun(t: Terminal) -- function to run when the terminal closes
       -- callbacks for processing the output
-      on_stdout = fun(job: number, exit_code: number, type: string)
-      on_stderr = fun(job: number, data: string[], name: string)
-      on_exit = fun(job: number, data: string[], name: string)
+      on_stdout = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stdout
+      on_stderr = fun(t: Terminal, job: number, data: string[], name: string) -- callback for processing output on stderr
+      on_exit = fun(t: Terminal, job: number, exit_code: number, name: string) -- function to run when terminal process exits
     }
 <
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -271,7 +271,7 @@ end
 ---@private
 ---Pass self as first parameter to callback
 function Terminal:__stdout()
-  if type(self.on_stdout) == "function" then
+  if self.on_stdout then
     return function(...)
       self.on_stdout(self, ...)
     end
@@ -281,7 +281,7 @@ end
 ---@private
 ---Pass self as first parameter to callback
 function Terminal:__stderr()
-  if type(self.on_stderr) == "function" then
+  if self.on_stderr then
     return function(...)
       self.on_stderr(self, ...)
     end

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -153,12 +153,6 @@ function M.stopinsert()
   vim.cmd("stopinsert!")
 end
 
---- @param win_id number
---- @return boolean
-function M.try_open(win_id)
-  return fn.win_gotoid(win_id) > 0
-end
-
 --- Find the first open terminal window
 --- by iterating all windows and matching the
 --- containing buffers filetype with the passed in


### PR DESCRIPTION
Previously it was necessary to always create a new custom Terminal instance to attach `on_stdout()` and `on_stderr()` functions. With this PR these functions can be configured globally and thus serve as a default for *all* terminals.

A wrapper will add the corresponding terminal as the first parameter to `on_stdout()` and `on_stderr()` to be consistent with how on_exit() is called (dot operator vs colon operator). This is technically a breaking change, but since the documentation for `on_exit()` has been wrong all this time without anyone complaining I don't know if this would have any real impact on the wider userbase.

It also no longer tries to switch the terminal window just see if it is open or not. `win_gettype()` will return an empty string for normal windows, or "unknown" if the window doesn't exist. I removed `try_open()` completely since it only contained a single line of code and wasn't referenced anywhere else.