### PR TITLE
fix: create terminal with called ID if not found

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -394,7 +394,7 @@ function M.get_or_create_term(num, dir, direction)
   if term then
     return term, false
   end
-  return Terminal:new({ dir = dir, direction = direction }), true
+  return Terminal:new({ id = num, dir = dir, direction = direction }), true
 end
 
 ---Get a single terminal by id, unless it is hidden


### PR DESCRIPTION
When using `5ToggleTerm`, but there is no terminal with id=5, a new terminal was created, *but not with id=5*. Instead a new terminal was created by calling `next_id()`, creating the weird behavior where `5ToggleTerm` would create new terminals until `next_id()` would finally return 5.

This PR fixes this by creating a new terminal with the specified ID when such a terminal does not already exist.

 fixes #146