### PR TITLE
fix: toggle floating windows properly

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -187,8 +187,9 @@ function Terminal:is_open()
   if not self.window then
     return false
   end
-  -- empty string corresponds to a normal window
-  local win_open = fn.win_gettype(self.window) == ""
+  local win_type = fn.win_gettype(self.window)
+  -- empty string window type corresponds to a normal window
+  local win_open = win_type == "" or win_type == "popup"
   return win_open and api.nvim_win_get_buf(self.window) == self.bufnr
 end
 


### PR DESCRIPTION
A bug was introduced in #162 that causes floating terminal windows to not close as expected when toggling, due to the change in the `Terminal:is_open` method:
```diff
-  --- TODO: try open will actually attempt to switch to this window
-   local win_open = ui.try_open(self.window)
+   -- empty string corresponds to a normal window
+   local win_open = fn.win_gettype(self.window) == ""
```

You can observe the issue when configuring a terminal toggle with a `"float"` direction. This fix includes an additional check on the window type to handle floating (`"popup"`) window types.