### PR TITLE
feat(highlights): add custom highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Terminal:new {
   direction = string -- the layout for the terminal, same as the main config options
   dir = string -- the directory for the terminal
   close_on_exit = bool -- close the terminal window when the process exits
+  highlights = table -- a table with highlights (float terminal not supported)
   on_open = fun(t: Terminal) -- function to run when the terminal opens
   on_close = fun(t: Terminal) -- function to run when the terminal closes
   -- callbacks for processing the output

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -146,6 +146,14 @@ function Terminal:new(term)
   term.direction = term.direction == "window" and "tab" or term.direction
   term.id = id or next_id()
   term.hidden = term.hidden or false
+  term.highlights = vim.tbl_deep_extend("keep", term.highlights or {}, {
+    Normal = "ToggleTermNormal",
+    EndOfBuffer = "ToggleTermEndOfBuffer",
+    VertSplit = "ToggleTermVertSplit",
+    StatusLine = "ToggleTermStatusLine",
+    StatusLineNC = "ToggleTermStatusLineNC",
+    SignColumn = "ToggleTermSignColumn",
+  })
   term.float_opts = vim.tbl_deep_extend("keep", term.float_opts or {}, conf.float_opts)
   term.on_open = term.on_open or conf.on_open
   term.on_close = term.on_close or conf.on_close

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -77,7 +77,7 @@ end
 ---apply highlights to a terminal
 ---@param term Terminal
 function M.hl_term(term)
-  local highlights
+  local highlights = {}
   local config = require("toggleterm.config")
   if term and term:is_float() or M.is_float() then
     local opts = term and term.float_opts or config.get("float_opts") or {}
@@ -85,6 +85,10 @@ function M.hl_term(term)
       fmt("NormalFloat:%s", opts.highlights.background),
       fmt("FloatBorder:%s", opts.highlights.border),
     }
+  elseif not vim.tbl_isempty(term.highlights) then
+    for key, value in pairs(term.highlights) do
+      highlights[#highlights + 1] = key .. ":" .. value
+    end
   elseif config.get("shade_terminals") then
     highlights = {
       "Normal:DarkenedPanel",

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -5,6 +5,14 @@ if !has('nvim-0.5')
   finish
 endif
 
+" ToggleTerm Highlights
+highlight default link ToggleTermNormal Normal
+highlight default link ToggleTermEndOfBuffer EndOfBuffer
+highlight default link ToggleTermVertSplit VertSplit
+highlight default link ToggleTermStatusLine StatusLine
+highlight default link ToggleTermStatusLineNC StatusLineNC
+highlight default link ToggleTermSignColumn SignColumn
+
 "--------------------------------------------------------------------------------
 " Commands
 "--------------------------------------------------------------------------------


### PR DESCRIPTION
This PR add support to highlights

```lua
local Term = require('toggleterm.terminal').Terminal:new {
  highlights = {
    Normal = 'Normal',
    EndOfBuffer = 'EndOfBuffer',
    VertSplit = 'VertSplit',
    StatusLine = 'StatusLine',
    StatusLineNC = 'StatusLineNC',
    SignColumn = 'SignColumn',
  },
}
```