### PR TITLE
feat: send line(s) to the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,4 +417,10 @@ You can "send lines" to the toggled terminals with the following commands:
 (`<T_ID` is an optional terminal ID parameter which defines where should we send the lines.
 If the parameter is not provided, then the default is the `first terminal`)
 
+<!-- panvimdoc-ignore-start -->
 
+Example:
+
+<video src="https://user-images.githubusercontent.com/18753533/159889865-724becab-877b-45a2-898e-820afd6a4ee1.mov" controls="controls" muted="muted" height="640px">
+
+<!-- panvimdoc-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ If the parameter is not provided, then the default is the `first terminal`)
 
 Example:
 
-<video src="https://user-images.githubusercontent.com/18753533/159889865-724becab-877b-45a2-898e-820afd6a4ee1.mov" controls="controls" muted="muted" height="640px">
+<video src="https://user-images.githubusercontent.com/18753533/159889865-724becab-877b-45a2-898e-820afd6a4ee1.mov" controls="controls" muted="muted" height="640px"></video>
 
 <!-- panvimdoc-ignore-end -->
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,24 @@ You can send commands to a terminal without opening its window by using the `ope
 
 see `:h expand()` for more details
 
+### Sending lines to the terminal
+
+You can "send lines" to the toggled terminals with the following commands:
+- `:ToggleTermSendCurrentLine <T_ID>`: sends the whole line where you are currently standing with your cursor
+- `:ToggleTermSendVisualLines <T_ID>`: sends all of the (whole) lines in your visual selection
+- `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection in a  single line)
+
+(`<T_ID` is an optional terminal ID parameter which defines where should we send the lines.
+If the parameter is not provided, then the default is the `first terminal`)
+
+<!-- panvimdoc-ignore-start -->
+
+Example:
+
+<video src="https://user-images.githubusercontent.com/18753533/159889865-724becab-877b-45a2-898e-820afd6a4ee1.mov" controls="controls" muted="muted" height="640px">
+
+<!-- panvimdoc-ignore-end -->
+
 ### Set terminal shading
 
 This plugin automatically shades terminal filetypes to be darker than other window
@@ -406,21 +424,3 @@ Explain:
 
 - `2`: this is the terminal's number (or ID), your first terminal is `1` (e.g. your 3rd terminal will be `3<C-\>`, so on).
 - <kbd>C-\\</kbd>: this is the combined key mapping to the command `:ToggleTerm`.
-
-### Sending lines to the terminal
-
-You can "send lines" to the toggled terminals with the following commands:
-- `:ToggleTermSendCurrentLine <T_ID>`: sends the whole line where you are currently standing with your cursor
-- `:ToggleTermSendVisualLines <T_ID>`: sends all of the (whole) lines in your visual selection
-- `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection in a  single line)
-
-(`<T_ID` is an optional terminal ID parameter which defines where should we send the lines.
-If the parameter is not provided, then the default is the `first terminal`)
-
-<!-- panvimdoc-ignore-start -->
-
-Example:
-
-<video src="https://user-images.githubusercontent.com/18753533/159889865-724becab-877b-45a2-898e-820afd6a4ee1.mov" controls="controls" muted="muted" height="640px">
-
-<!-- panvimdoc-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Explain:
 You can "send lines" to the toggled terminals with the following commands:
 - `:ToggleTermSendCurrentLine <T_ID>`: sends the whole line where you are currently standing with your cursor
 - `:ToggleTermSendVisualLines <T_ID>`: sends all of the (whole) lines in your visual selection
-- `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection ina  single line)
+- `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection in a  single line)
 
 (`<T_ID` is an optional terminal ID parameter which defines where should we send the lines.
 If the parameter is not provided, then the default is the `first terminal`)

--- a/README.md
+++ b/README.md
@@ -406,3 +406,15 @@ Explain:
 
 - `2`: this is the terminal's number (or ID), your first terminal is `1` (e.g. your 3rd terminal will be `3<C-\>`, so on).
 - <kbd>C-\\</kbd>: this is the combined key mapping to the command `:ToggleTerm`.
+
+### Sending lines to the terminal
+
+You can "send lines" to the toggled terminals with the following commands:
+- `:ToggleTermSendCurrentLine <T_ID>`: sends the whole line where you are currently standing with your cursor
+- `:ToggleTermSendVisualLines <T_ID>`: sends all of the (whole) lines in your visual selection
+- `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection ina  single line)
+
+(`<T_ID` is an optional terminal ID parameter which defines where should we send the lines.
+If the parameter is not provided, then the default is the `first terminal`)
+
+

--- a/lua/asd.lua
+++ b/lua/asd.lua
@@ -1,4 +1,0 @@
-local asd
-
-asd = asd or 12
-print(asd)

--- a/lua/asd.lua
+++ b/lua/asd.lua
@@ -1,0 +1,4 @@
+local asd
+
+asd = asd or 12
+print(asd)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -186,6 +186,7 @@ end
 
 --- @param selection_type string
 --- @param trim_spaces boolean
+--- @param terminal_id number
 function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
     -- trim_spaces defines if we should trim the spaces from lines which are sent to the terminal
     if trim_spaces == nil then

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -189,10 +189,10 @@ end
 --- @param terminal_id number
 function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   -- trim_spaces defines if we should trim the spaces from lines which are sent to the terminal
-  if trim_spaces == nil then trim_spaces = true end
+  trim_spaces = trim_spaces or true
 
   -- If no terminal id provided fall back to the default
-  if terminal_id == nil then terminal_id = 1 end
+  terminal_id = terminal_id or 1
   terminal_id = tonumber(terminal_id)
 
   vim.validate({

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -208,7 +208,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   -- Beginning of the selection: line number, column number
   local b_line, b_col
 
-  local function _line_selection(mode)
+  local function line_selection(mode)
     local start_char, end_char
     if mode == "visual" then
       start_char = "'<"
@@ -226,7 +226,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   end
 
   if selection_type == "visual_lines" or selection_type == "visual_selection" then
-    local res = _line_selection("visual")
+    local res = line_selection("visual")
     b_line, b_col = unpack(res.start_pos)
     lines = res.selected_lines
 

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -194,7 +194,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   end
 
   if terminal_id == nil then
-      -- If not terminal id provided fall back to the default
+      -- If no terminal id provided fall back to the default
       terminal_id = 1
   end
   terminal_id = tonumber(terminal_id)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -189,7 +189,7 @@ end
 --- @param terminal_id number
 function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   -- trim_spaces defines if we should trim the spaces from lines which are sent to the terminal
-  trim_spaces = trim_spaces or true
+  trim_spaces = trim_spaces == nil or trim_spaces
 
   -- If no terminal id provided fall back to the default
   terminal_id = terminal_id or 1

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -188,15 +188,11 @@ end
 --- @param trim_spaces boolean
 --- @param terminal_id number
 function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
-    -- trim_spaces defines if we should trim the spaces from lines which are sent to the terminal
-    if trim_spaces == nil then
-      trim_spaces = true
-  end
+  -- trim_spaces defines if we should trim the spaces from lines which are sent to the terminal
+  if trim_spaces == nil then trim_spaces = true end
 
-  if terminal_id == nil then
-      -- If no terminal id provided fall back to the default
-      terminal_id = 1
-  end
+  -- If no terminal id provided fall back to the default
+  if terminal_id == nil then terminal_id = 1 end
   terminal_id = tonumber(terminal_id)
 
   vim.validate({
@@ -213,37 +209,37 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   local b_line, b_col
 
   local function _line_selection(mode)
-      local start_char, end_char
-      if mode == "visual" then
-          start_char = "'<"
-          end_char = "'>"
-      elseif mode == "motion" then
-          start_char = "'["
-          end_char = "']"
-      end
+    local start_char, end_char
+    if mode == "visual" then
+      start_char = "'<"
+      end_char = "'>"
+    elseif mode == "motion" then
+      start_char = "'["
+      end_char = "']"
+    end
 
-      -- Get the start and the end of the selection
-      local start_line, start_col = unpack(vim.fn.getpos(start_char), 2, 3)
-      local end_line, end_col = unpack(vim.fn.getpos(end_char), 2, 3)
-      local selected_lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
-      return {start_pos={start_line, start_col}, end_pos={end_line, end_col}, selected_lines=selected_lines}
+    -- Get the start and the end of the selection
+    local start_line, start_col = unpack(vim.fn.getpos(start_char), 2, 3)
+    local end_line, end_col = unpack(vim.fn.getpos(end_char), 2, 3)
+    local selected_lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
+    return {start_pos={start_line, start_col}, end_pos={end_line, end_col}, selected_lines=selected_lines}
   end
 
   if selection_type == "visual_lines" or selection_type == "visual_selection" then
-      local res = _line_selection("visual")
-      b_line, b_col = unpack(res.start_pos)
-      lines = res.selected_lines
-      local _, e_col = unpack(res.end_pos)
+    local res = _line_selection("visual")
+    b_line, b_col = unpack(res.start_pos)
+    lines = res.selected_lines
 
-      if selection_type == "visual_selection" then
-          -- Visual selection is more accurate, as we get the sub-string of every line based on the visual selection
-         for i, v in ipairs(lines) do
-             lines[i] = v:sub(b_col, e_col)
-         end
-      end
+    if selection_type == "visual_selection" then
+      -- Visual selection is more accurate, as we get the sub-string of every line based on the visual selection
+      local _, e_col = unpack(res.end_pos)
+     for i, v in ipairs(lines) do
+         lines[i] = v:sub(b_col, e_col)
+     end
+    end
   elseif selection_type == "single_line" then
-      b_line, b_col = unpack(vim.api.nvim_win_get_cursor(0))
-      table.insert(lines, vim.fn.getline(b_line))
+    b_line, b_col = unpack(vim.api.nvim_win_get_cursor(0))
+    table.insert(lines, vim.fn.getline(b_line))
   end
 
   -- If no lines are fetched we don't need to do anything
@@ -251,11 +247,11 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
 
   -- Send each line to the terminal after some preprocessing if required
   for _, v in ipairs(lines) do
-      -- Trim whitespaces from the strings
-      if trim_spaces then
-          v = v:gsub("^%s+", ""):gsub("%s+$", "")
-      end
-      M.exec(v, terminal_id)
+    -- Trim whitespaces from the strings
+    if trim_spaces then
+      v = v:gsub("^%s+", ""):gsub("%s+$", "")
+    end
+    M.exec(v, terminal_id)
   end
 
   -- Jump back with the cursor where we were at the begiining of the selection

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -202,7 +202,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   })
 
   -- Window number from where we are calling the function (needed so we can get back to it automatically)
-  local current_window = vim.api.nvim_get_current_win()
+  local current_window = api.nvim_get_current_win()
   -- Line texts - these will be sent over to the terminal one by one
   local lines = {}
   -- Beginning of the selection: line number, column number
@@ -219,9 +219,9 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
     end
 
     -- Get the start and the end of the selection
-    local start_line, start_col = unpack(vim.fn.getpos(start_char), 2, 3)
-    local end_line, end_col = unpack(vim.fn.getpos(end_char), 2, 3)
-    local selected_lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
+    local start_line, start_col = unpack(fn.getpos(start_char), 2, 3)
+    local end_line, end_col = unpack(fn.getpos(end_char), 2, 3)
+    local selected_lines = api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
     return {start_pos={start_line, start_col}, end_pos={end_line, end_col}, selected_lines=selected_lines}
   end
 
@@ -238,8 +238,8 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
      end
     end
   elseif selection_type == "single_line" then
-    b_line, b_col = unpack(vim.api.nvim_win_get_cursor(0))
-    table.insert(lines, vim.fn.getline(b_line))
+    b_line, b_col = unpack(api.nvim_win_get_cursor(0))
+    table.insert(lines, fn.getline(b_line))
   end
 
   -- If no lines are fetched we don't need to do anything
@@ -248,14 +248,12 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   -- Send each line to the terminal after some preprocessing if required
   for _, v in ipairs(lines) do
     -- Trim whitespaces from the strings
-    if trim_spaces then
-      v = v:gsub("^%s+", ""):gsub("%s+$", "")
-    end
+    v = trim_spaces and v:gsub("^%s+", ""):gsub("%s+$", "") or v
     M.exec(v, terminal_id)
   end
 
   -- Jump back with the cursor where we were at the begiining of the selection
-  vim.api.nvim_win_set_cursor(current_window, {b_line, b_col})
+  api.nvim_win_set_cursor(current_window, {b_line, b_col})
 end
 
 function M.toggle_command(args, count)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -12,5 +12,6 @@ endif
 command! -count -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>, <count>)
 command! -count -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>, <count>)
 command! -bang ToggleTermToggleAll lua require'toggleterm'.toggle_all(<q-bang>)
-command! -range ToggleTermSendCurrentVisual '<,'> lua require'toggleterm'.send_lines_to_terminal('visual')<CR>
-command! ToggleTermSendCurrentLine lua require'toggleterm'.send_lines_to_terminal('single_line')<CR>
+command! -range -nargs=? ToggleTermSendVisualLines '<,'> lua require'toggleterm'.send_lines_to_terminal('visual_lines', true, <q-args>)<CR>
+command! -range -nargs=? ToggleTermSendVisualSelection '<,'> lua require'toggleterm'.send_lines_to_terminal('visual_selection', true, <q-args>)<CR>
+command! -nargs=? ToggleTermSendCurrentLine lua require'toggleterm'.send_lines_to_terminal('single_line', true, <q-args>)<CR>

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -12,3 +12,5 @@ endif
 command! -count -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>, <count>)
 command! -count -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>, <count>)
 command! -bang ToggleTermToggleAll lua require'toggleterm'.toggle_all(<q-bang>)
+command! -range ToggleTermSendCurrentVisual '<,'> lua require'toggleterm'.send_lines_to_terminal('visual')<CR>
+command! ToggleTermSendCurrentLine lua require'toggleterm'.send_lines_to_terminal('single_line')<CR>


### PR DESCRIPTION
#172 

Purpose of the PR is to make "sending lines" from a file to the toggled terminal available for the user (as simple as possible). Can come handy in multiple situations (e.g. executing code with `ipython`)

The PR contains:
- Sending a single line where our cursor is `:ToggleTermSendCurrentLine <T_ID>`
- Sending the lines from a visual selection `:ToggleTermSendVisualLines <T_ID>`
- Sending the visual selection (e.g. block of code, single word) `:ToggleTermSendVisualSelection <T_ID>`

(`<T_ID>` is an optional argument. It's the ID of the terminal where we want to send the line(s) )

Example

![toggleterm_test](https://user-images.githubusercontent.com/18753533/157638816-4ef8dbb0-fb7e-4889-96ea-682d919cda57.gif)