### PR TITLE
Fix separator on pwsh

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -21,7 +21,7 @@ local function is_pwsh()
 end
 
 local function get_command_sep()
-  return is_windows and is_cmd() and "&" or ";"
+  return is_windows and "&" or ";"
 end
 
 local function get_comment_sep()


### PR DESCRIPTION
On Windows it should always be `&`.