### PR TITLE
fix(send_lines): place cursor back in the original window

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -261,6 +261,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   end
 
   -- Jump back with the cursor where we were at the begiining of the selection
+  api.nvim_set_current_win(current_window)
   api.nvim_win_set_cursor(current_window, { b_line, b_col })
 end
 


### PR DESCRIPTION
Thanks for this awesome plugin first! This PR tries to fix the bug of the cursor jumping back problem since the function `nvim_win_set_cursor` simply sets the cursor position on that window without jumping back to it.