### PR TITLE
fix(ui): handle highlighting unknown terminals

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -326,21 +326,22 @@ end
 function M.setup(user_prefs)
   local conf = require("toggleterm.config").set(user_prefs)
   setup_global_mappings()
+  local toggleterm_pattern = "term://*#toggleterm#*"
   local autocommands = {
     {
       "WinEnter",
-      "term://*toggleterm*",
+      toggleterm_pattern,
       "nested", -- this is necessary in case the buffer is the last
       "lua require'toggleterm'.handle_term_enter()",
     },
     {
       "WinLeave",
-      "term://*toggleterm*",
+      toggleterm_pattern,
       "lua require'toggleterm'.handle_term_leave()",
     },
     {
       "TermOpen",
-      "term://*toggleterm*",
+      toggleterm_pattern,
       "lua require'toggleterm'.on_term_open()",
     },
   }


### PR DESCRIPTION
This PR fixes #203 which is caused by terminals not known to toggleterm being highlighted but not being of type `Terminal` so missing the methods and variables that were expected. I've added defaults within that function but it might be worth being able to represent unknown terminals at some point