### PR TITLE
feat: add api to spawn tasks without opening a window

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,12 @@ end
 vim.api.nvim_set_keymap("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
 ```
 
-This will create a new terminal that runs the specified command once toggled
-if the `hidden` key is set to true. This terminal will not be toggled by normal toggleterm
-commands such as `:ToggleTerm` or the open mapping. It will only open and close in response to a user
-specified mapping like the above.
+This will create a new terminal but the specified command is not being run immediately.
+The command will run once the terminal is opened. Alternatively `term:spawn()` can be used
+to start the command in a background buffer without opening a terminal window yet. If the
+`hidden` key is set to true, this terminal will not be toggled by normal toggleterm commands
+such as `:ToggleTerm` or the open mapping. It will only open and close by using the returned
+terminal object. A mapping for toggling the terminal can be set as in the example above.
 
 Alternatively the terminal can be specified with a count which is the number that can be used
 to trigger this specific terminal. This can then be triggered using the current count e.g.

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -362,7 +362,7 @@ end
 
 ---Spawn terminal background job in a buffer without a window
 function Terminal:spawn()
-  if fn.bufexists(self.bufnr) == 0 then
+  if not (self.bufnr and api.nvim_buf_is_valid(self.bufnr)) then
     self.bufnr = api.nvim_create_buf(false, false)
     self:__add()
     api.nvim_buf_call(self.bufnr, function()
@@ -383,7 +383,7 @@ function Terminal:open(size, direction, is_new)
   if direction then
     self:change_direction(direction)
   end
-  if fn.bufexists(self.bufnr) == 0 then
+  if not (self.bufnr and api.nvim_buf_is_valid(self.bufnr)) then
     local ok, err = pcall(opener, size, self)
     if not ok then
       return utils.notify(err, "error")

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -123,7 +123,10 @@ local function setup_buffer_autocommands(term)
   }
 
   if conf.start_in_insert then
-    vim.cmd("startinsert")
+    -- Avoid entering insert mode when spawning terminal in the background
+    if term.window == api.nvim_get_current_win() then
+      vim.cmd("startinsert")
+    end
     table.insert(commands, {
       "BufEnter",
       fmt("<buffer=%d>", term.bufnr),

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -360,6 +360,19 @@ local function opener(size, term)
   end
 end
 
+---Spawn terminal background job in a buffer without a window
+function Terminal:spawn()
+  if fn.bufexists(self.bufnr) == 0 then
+    self.bufnr = vim.api.nvim_create_buf(false, false)
+    self:__add()
+    vim.api.nvim_buf_call(self.bufnr, function()
+      self:__spawn()
+    end)
+    setup_buffer_autocommands(self)
+    setup_buffer_mappings(self.bufnr)
+  end
+end
+
 ---Open a terminal window
 ---@param size number
 ---@param direction string

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -363,9 +363,9 @@ end
 ---Spawn terminal background job in a buffer without a window
 function Terminal:spawn()
   if fn.bufexists(self.bufnr) == 0 then
-    self.bufnr = vim.api.nvim_create_buf(false, false)
+    self.bufnr = api.nvim_create_buf(false, false)
     self:__add()
-    vim.api.nvim_buf_call(self.bufnr, function()
+    api.nvim_buf_call(self.bufnr, function()
       self:__spawn()
     end)
     setup_buffer_autocommands(self)

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -363,7 +363,7 @@ end
 ---Spawn terminal background job in a buffer without a window
 function Terminal:spawn()
   if not (self.bufnr and api.nvim_buf_is_valid(self.bufnr)) then
-    self.bufnr = api.nvim_create_buf(false, false)
+    self.bufnr = ui.create_buf()
     self:__add()
     api.nvim_buf_call(self.bufnr, function()
       self:__spawn()

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -130,6 +130,10 @@ local function create_term_buf_if_needed(term)
   term.window, term.bufnr = window, bufnr
 end
 
+function M.create_buf()
+    return api.nvim_create_buf(false, false)
+end
+
 function M.delete_buf(term)
   if term.bufnr and api.nvim_buf_is_valid(term.bufnr) then
     api.nvim_buf_delete(term.bufnr, { force = true })


### PR DESCRIPTION
I was trying to spawn multiple terminal jobs in the background, but it seems that without `task:open()` the jobs won't be started. It is possible to do `task:open(); task:close()`, at least with `direction='float'`, but doing this for multiple terminals at once seems wrong.

This PR adds `task:spawn()` which only creates terminal buffer with the job, without opening a window yet. The window can be opened later and it doesn't seem to cause any problems. Using `nvim_buf_call` it was possible to make the `termopen` call actually use the background buffer instead of the current one.