### PR TITLE
fix: shade_color

### DIFF
--- a/lua/toggleterm/colors.lua
+++ b/lua/toggleterm/colors.lua
@@ -35,7 +35,7 @@ function M.shade_color(color, percent)
   r, g, b = r < 255 and r or 255, g < 255 and g or 255, b < 255 and b or 255
 
   -- see: https://stackoverflow.com/questions/37796287/convert-decimal-to-hex-in-lua-4
-  r, g, b = string.format("%0x", r), string.format("%0x", g), string.format("%0x", b)
+  r, g, b = string.format("%02x", r), string.format("%02x", g), string.format("%02x", b)
   return "#" .. r .. g .. b
 end
 


### PR DESCRIPTION
Thanks for this awesome plugin first!
Sometimes `shade_color()` returns invalid color and fails to darken window.

For example, my colorsheme is [terafox](https://github.com/EdenEast/nightfox.nvim) and its background color is `'#152528'`.
In this case `shade_color('#152528', -30)` returns `'#e191c'` (not `'#0e191c'`).

Zero padding fixes this problem.