### PR TITLE
feat(terms): delete internal term resources on shutdown.

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -256,6 +256,7 @@ function Terminal:shutdown()
     self:close()
   end
   ui.delete_buf(self)
+  delete(self.id)
 end
 
 ---Combine arguments into strings separated by new lines
@@ -509,7 +510,6 @@ if _G.IS_TEST then
   function M.__reset()
     for _, term in pairs(terminals) do
       term:shutdown()
-      delete(term.id)
     end
     ids = {}
   end


### PR DESCRIPTION
Add delete call in the shutdown method for terminal, this will allow the terminal to properly be cleaned up when shutdown. Shutdown is used when
one desires to kill the terminal and not simply close it but rather
completely destroy it and free up a slot for another term instance.