### PR TITLE
Update toggleterm.lua

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -236,21 +236,66 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
     }
   end
 
-  if selection_type == "visual_lines" or selection_type == "visual_selection" then
+  local function get_visual_selection(res)
+    -- Return the text of the precise visual selection
+
+    local vis_mode = fn.visualmode()
+
+    if vis_mode == "V" then
+      -- line-visual
+      -- return lines encompassed by the selection; already in res object
+      return res.selected_lines
+
+    elseif vis_mode == "v" then
+      -- regular-visual
+      -- return the buffer text encompassed by the selection
+      local start_line, start_col = unpack(res.start_pos)
+      local end_line, end_col = unpack(res.end_pos)
+      -- exclude the last char in text if "selection" is set to "exclusive"
+      if opt.selection._value == "exclusive" then
+        end_col = end_col - 1
+      end
+      return api.nvim_buf_get_text(
+        0, start_line - 1, start_col - 1, end_line - 1, end_col, {}
+      )
+
+    elseif vis_mode == "\x16" then
+      -- block-visual
+      -- return the lines encompassed by the selection, each truncated by the
+      -- start and end columns
+      local _, start_col = unpack(res.start_pos)
+      local _, end_col = unpack(res.end_pos)
+      -- exclude the last col of the block if "selection" is set to "exclusive"
+      if opt.selection._value == "exclusive" then
+        end_col = end_col - 1
+      end
+      -- exchange start and end columns for proper substring indexing if needed
+      -- e.g. instead of str:sub(10, 5), do str:sub(5, 10)
+      if start_col > end_col then
+        start_col, end_col = end_col, start_col
+      end
+      -- iterate over lines, truncating each one
+      local block_lines = {}
+      for i, v in ipairs(res.selected_lines) do
+        block_lines[i] = v:sub(start_col, end_col)
+      end
+      return block_lines
+    end
+  end
+
+  if selection_type == "single_line" then
+    b_line, b_col = unpack(api.nvim_win_get_cursor(0))
+    table.insert(lines, fn.getline(b_line))
+
+  elseif selection_type == "visual_lines" then
     local res = line_selection("visual")
     b_line, b_col = unpack(res.start_pos)
     lines = res.selected_lines
 
-    if selection_type == "visual_selection" then
-      -- Visual selection is more accurate, as we get the sub-string of every line based on the visual selection
-      local _, e_col = unpack(res.end_pos)
-      for i, v in ipairs(lines) do
-        lines[i] = v:sub(b_col, e_col)
-      end
-    end
-  elseif selection_type == "single_line" then
-    b_line, b_col = unpack(api.nvim_win_get_cursor(0))
-    table.insert(lines, fn.getline(b_line))
+  elseif selection_type == "visual_selection" then
+    local res = line_selection("visual")
+    b_line, b_col = unpack(res.start_pos)
+    lines = get_visual_selection(res)
   end
 
   -- If no lines are fetched we don't need to do anything


### PR DESCRIPTION
Update the ToggleTermSendVisualSelection command by changing the "visual_selection" logic in M.send_lines_to_terminal.
For selection_type == "visual_selection", the lines now come from the new local function get_visual_selection which gets the lines based on the visual mode used to make the selection.

One thing I forgot to add was defining "opt" at the top of the file:
```lua
local opt = vim.opt
```
