### PR TITLE
fix(next_id): Terminal IDs should be unique.

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -59,33 +59,19 @@ local terminals = {}
 --- @field on_close fun(term:Terminal)
 local Terminal = {}
 
----@type number[]
-local ids = {}
-
 ---@private
 --- Get the next available id based on the next number in the sequence that
 --- hasn't already been allocated e.g. in a list of {1,2,5,6} the next id should
 --- be 3 then 4 then 7
 ---@return integer
 local function next_id()
-  local next_to_use = #ids + 1
-  local next_index = #ids + 1
-  for index, id in ipairs(ids) do
-    if id ~= index then
-      next_to_use = index
-      next_index = index
+  local all = M.get_all(true)
+  for index, term in pairs(all) do
+    if index ~= term.id then
+      return index
     end
   end
-  table.insert(ids, next_index, next_to_use)
-  return next_to_use
-end
-
---- remove the passed id from the list of available ids
----@param num number
-local function decrement_id(num)
-  ids = vim.tbl_filter(function(id)
-    return id ~= num
-  end, ids)
+  return #all+1
 end
 
 ---Get an opened (valid) toggle terminal by id, defaults to the first opened
@@ -123,7 +109,6 @@ end
 --- @param num string
 local function delete(num)
   if terminals[num] then
-    decrement_id(num)
     terminals[num] = nil
   end
 end
@@ -511,13 +496,6 @@ if _G.IS_TEST then
     for _, term in pairs(terminals) do
       term:shutdown()
     end
-    ids = {}
-  end
-
-  ---@private
-  ---@param tbl number[]
-  function M.__set_ids(tbl)
-    ids = tbl
   end
 
   M.__next_id = next_id

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -45,13 +45,22 @@ describe("ToggleTerm tests:", function()
     end)
 
     it("should assign the next id filling in any missing gaps", function()
-      t.__set_ids({ 1, 2, 5 })
-      local id = t.__next_id()
-      assert.equal(id, 3)
-      id = t.__next_id()
-      assert.equal(id, 4)
-      id = t.__next_id()
-      assert.equal(id, 6)
+      Terminal:new({ id = 2}):toggle() --2
+      Terminal:new():toggle() --1
+      Terminal:new():toggle() --3
+      Terminal:new():toggle() --4
+      Terminal:new({ id = 6 }):toggle() --6
+      local terms = get_all()
+      terms[3]:shutdown()
+      terms[1]:shutdown()
+      local new1 = Terminal:new():toggle()
+      assert.equal(1, new1.id)
+      local new3 = Terminal:new():toggle()
+      assert.equal(3, new3.id)
+      local new5 = Terminal:new():toggle()
+      assert.equal(5, new5.id)
+      local new7 = Terminal:new():toggle()
+      assert.equal(7, new7.id)
     end)
 
     it("should get terminals as a list", function()


### PR DESCRIPTION
Simplified next_id() by removing the 'ids' table and calling
get_all() instead. The previous implementation did not always
produce unique IDs.

Remodelled the next_id test case by creating actuall terminals.

Before this patch, if you created 3 terminals with ID 1, 2, 3
and then closed the first terminal with id 1 using "exit",
the next_id was calculated to 2, resulting in a duplicate ID.