### PR TITLE
feat: persist terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ require("toggleterm").setup{
     -- highlights which map to a highlight group name and a table of it's values
     -- NOTE: this is only a subset of values, any group placed here will be set for the terminal window split
     Normal = {
-      guibg = <VALUE-HERE>,
+      guibg = "<VALUE-HERE>",
     },
     NormalFloat = {
       link = 'Normal'
     },
     FloatBorder = {
-      guifg = <VALUE-HERE>,
-      guibg = <VALUE-HERE>,
+      guifg = "<VALUE-HERE>",
+      guibg = "<VALUE-HERE>",
     },
   },
   shade_terminals = true, -- NOTE: this option takes priority over highlights specified so if you specify Normal highlights you should set this to false
@@ -164,6 +164,7 @@ require("toggleterm").setup{
   insert_mappings = true, -- whether or not the open mapping applies in insert mode
   terminal_mappings = true, -- whether or not the open mapping applies in the opened terminals
   persist_size = true,
+  persist_mode = true, -- if set to true (default) the previous terminal mode will be remembered
   direction = 'vertical' | 'horizontal' | 'tab' | 'float',
   close_on_exit = true, -- close the terminal window when the process exits
   shell = vim.o.shell, -- change the default shell
@@ -346,7 +347,7 @@ Terminal:new {
 }
 ```
 
-#### Usage
+#### Custom terminal usage
 
 ```lua
 local Terminal  = require('toggleterm.terminal').Terminal

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -137,14 +137,14 @@ show what options are available. It is not written be used as is.
         -- highlights which map to a highlight group name and a table of it's values
         -- NOTE: this is only a subset of values, any group placed here will be set for the terminal window split
         Normal = {
-          guibg = <VALUE-HERE>,
+          guibg = "<VALUE-HERE>",
         },
         NormalFloat = {
           link = 'Normal'
         },
         FloatBorder = {
-          guifg = <VALUE-HERE>,
-          guibg = <VALUE-HERE>,
+          guifg = "<VALUE-HERE>",
+          guibg = "<VALUE-HERE>",
         },
       },
       shade_terminals = true, -- NOTE: this option takes priority over highlights specified so if you specify Normal highlights you should set this to false
@@ -153,6 +153,7 @@ show what options are available. It is not written be used as is.
       insert_mappings = true, -- whether or not the open mapping applies in insert mode
       terminal_mappings = true, -- whether or not the open mapping applies in the opened terminals
       persist_size = true,
+      persist_mode = true, -- if set to true (default) the previous terminal mode will be remembered
       direction = 'vertical' | 'horizontal' | 'tab' | 'float',
       close_on_exit = true, -- close the terminal window when the process exits
       shell = vim.o.shell, -- change the default shell
@@ -345,7 +346,7 @@ Each terminal can take the following arguments:
 <
 
 
-                                                            *toggleterm-Usage*
+                                            *toggleterm-Custom-terminal-usage*
 
 >
     local Terminal  = require('toggleterm.terminal').Terminal
@@ -359,7 +360,7 @@ Each terminal can take the following arguments:
 <
 
 
-Usage                                  This will create a new terminal but the
+Custom terminal usage                  This will create a new terminal but the
                                        specified command is not being run
                                        immediately. The command will run once
                                        the terminal is opened. Alternatively

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -106,7 +106,11 @@ local function handle_term_enter()
   local _, term = terms.identify()
   if term then
     close_last_window(term)
-    term:restore_mode()
+    if config.get("persist_mode") then
+      term:__restore_mode()
+    elseif config.get("start_in_insert") then
+      term:set_mode(terms.mode.INSERT)
+    end
   end
 end
 
@@ -115,7 +119,7 @@ local function handle_term_leave()
   if term and term:is_float() then
     term:close()
   end
-  if term then
+  if term and config.get("persist_mode") then
     term:persist_mode()
   end
 end

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -106,6 +106,7 @@ local function handle_term_enter()
   local _, term = terms.identify()
   if term then
     close_last_window(term)
+    term:restore_mode()
   end
 end
 
@@ -113,6 +114,9 @@ local function handle_term_leave()
   local _, term = terms.identify()
   if term and term:is_float() then
     term:close()
+  end
+  if term then
+    term:persist_mode()
   end
 end
 
@@ -373,14 +377,14 @@ local function setup_autocommands(_)
   api.nvim_create_augroup(AUGROUP, { clear = true })
   local toggleterm_pattern = "term://*#toggleterm#*"
 
-  api.nvim_create_autocmd("WinEnter", {
+  api.nvim_create_autocmd("BufWinEnter", {
     pattern = toggleterm_pattern,
     group = AUGROUP,
     nested = true, -- this is necessary in case the buffer is the last
     callback = handle_term_enter,
   })
 
-  api.nvim_create_autocmd("WinLeave", {
+  api.nvim_create_autocmd("BufWinLeave", {
     pattern = toggleterm_pattern,
     group = AUGROUP,
     callback = handle_term_leave,

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -246,7 +246,6 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
       -- line-visual
       -- return lines encompassed by the selection; already in res object
       return res.selected_lines
-
     elseif vis_mode == "v" then
       -- regular-visual
       -- return the buffer text encompassed by the selection
@@ -256,10 +255,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
       if opt.selection._value == "exclusive" then
         end_col = end_col - 1
       end
-      return api.nvim_buf_get_text(
-        0, start_line - 1, start_col - 1, end_line - 1, end_col, {}
-      )
-
+      return api.nvim_buf_get_text(0, start_line - 1, start_col - 1, end_line - 1, end_col, {})
     elseif vis_mode == "\x16" then
       -- block-visual
       -- return the lines encompassed by the selection, each truncated by the
@@ -287,12 +283,10 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, terminal_id)
   if selection_type == "single_line" then
     b_line, b_col = unpack(api.nvim_win_get_cursor(0))
     table.insert(lines, fn.getline(b_line))
-
   elseif selection_type == "visual_lines" then
     local res = line_selection("visual")
     b_line, b_col = unpack(res.start_pos)
     lines = res.selected_lines
-
   elseif selection_type == "visual_selection" then
     local res = line_selection("visual")
     b_line, b_col = unpack(res.start_pos)

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -20,6 +20,7 @@ end
 --- @field terminal_mappings boolean
 --- @field start_in_insert boolean
 --- @field persist_size boolean
+--- @field persist_mode boolean
 --- @field close_on_exit boolean
 --- @field direction  '"horizontal"' | '"vertical"' | '"float"'
 --- @field shading_factor number
@@ -36,6 +37,7 @@ local config = {
   terminal_mappings = true,
   start_in_insert = true,
   persist_size = true,
+  persist_mode = true,
   close_on_exit = true,
   direction = "horizontal",
   shading_factor = constants.shading_amount,

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -258,13 +258,10 @@ end
 
 function Terminal:persist_mode()
   local raw_mode = api.nvim_get_mode().mode
-  local normal_regex = vim.regex([[\(n\|no\|nov\|\nt\|niI\|niR\)]])
-  local insert_regex = vim.regex([[\(i\|ic\|ix\|t\)]])
-
   local m = "?"
-  if normal_regex:match_str(raw_mode) then
+  if raw_mode:match("nt") then -- nt is normal mode in the terminal
     m = mode.NORMAL
-  elseif insert_regex:match_str(raw_mode) then
+  elseif raw_mode:match("t") then -- t is insert mode in the terminal
     m = mode.INSERT
   end
   self.__state.mode = m

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -535,6 +535,7 @@ if _G.IS_TEST then
   end
 
   M.__next_id = next_id
+  M.mode = mode
 end
 
 M.Terminal = Terminal

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -43,8 +43,10 @@ local function get_newline_chr()
   return is_windows and (is_pwsh(shell) and "\r" or "\r\n") or "\n"
 end
 
+---@alias Mode "n" | "i" | "?"
+
 --- @class TerminalState
---- @field mode "n" | "i" | "?"
+--- @field mode Mode
 
 ---@type Terminal[]
 local terminals = {}
@@ -237,9 +239,14 @@ function Terminal:is_open()
   return win_open and api.nvim_win_get_buf(self.window) == self.bufnr
 end
 
-function Terminal:restore_mode()
-  local state = self.__state
-  local m = state.mode
+---@private
+function Terminal:__restore_mode()
+  self:set_mode(self.__state.mode)
+end
+
+--- Set the terminal's mode
+---@param m Mode
+function Terminal:set_mode(m)
   if m == mode.INSERT then
     vim.cmd("startinsert")
   elseif m == mode.NORMAL then
@@ -535,9 +542,9 @@ if _G.IS_TEST then
   end
 
   M.__next_id = next_id
-  M.mode = mode
 end
 
 M.Terminal = Terminal
+M.mode = mode
 
 return M

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -1,10 +1,14 @@
 local M = {}
 
 local lazy = require("toggleterm.lazy")
+---@module "toggleterm.ui"
 local ui = lazy.require("toggleterm.ui")
+---@module "toggleterm.config"
 local config = lazy.require("toggleterm.config")
+---@module "toggleterm.utils"
 local utils = lazy.require("toggleterm.utils")
-local term_ft = lazy.require("toggleterm.constants").term_ft
+---@module "toggleterm.constants"
+local constants = lazy.require("toggleterm.constants")
 local AUGROUP = "ToggleTermBuffer"
 
 local api = vim.api
@@ -334,7 +338,7 @@ function Terminal:__spawn()
     cmd,
     command_sep,
     comment_sep,
-    term_ft,
+    constants.term_ft,
     comment_sep,
     self.id,
   })

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -531,13 +531,11 @@ function M.get_all(include_hidden)
 end
 
 if _G.IS_TEST then
-  ---@private
   function M.__reset()
     for _, term in pairs(terminals) do
       term:shutdown()
     end
   end
-
   M.__next_id = next_id
 end
 

--- a/tests/state_spec.lua
+++ b/tests/state_spec.lua
@@ -1,0 +1,39 @@
+_G.IS_TEST = true
+
+local toggleterm = require("toggleterm")
+local t = require("toggleterm.terminal")
+
+local Terminal = t.Terminal
+
+describe("Terminal state - ", function()
+  vim.o.hidden = true
+  toggleterm.setup({ start_in_insert = true })
+
+  after_each(function()
+    require("toggleterm.terminal").__reset()
+  end)
+
+  it("should persist the terminal state when the window is closed", function()
+    local term = Terminal:new()
+    term:open()
+    vim.wait(500)
+    term:close()
+    vim.wait(500)
+    assert.is_not_true(vim.bo.buftype, "terminal")
+
+    assert.equal(term.__state.mode, t.mode.INSERT)
+  end)
+
+  it("should restore the terminal state when the window is re-opened", function()
+    local term = Terminal:new()
+    term:open()
+    vim.cmd("startinsert")
+    vim.wait(500)
+    term:close()
+    vim.wait(500)
+
+    term:open()
+    vim.wait(500)
+    assert.equal(term.__state.mode, t.mode.INSERT)
+  end)
+end)


### PR DESCRIPTION
This PR allows each terminal to keep track of the mode the user was last in and return to in when they re-open the terminal. Fixes #76

@kdheepak can you give this a try? it should keep track of the terminal state and re-use whatever it last was