### PR TITLE
docs(README): update `vim-plug` installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ end}
 Using vim-plug in vimscript
 
 ```vim
-Plug 'akinsho/toggleterm.nvim', tag = 'v1.*'
+Plug 'akinsho/toggleterm.nvim', {'tag' : 'v1.*'}
 ```
 
 You can/should specify a tag for the current major version of the plugin, to avoid breaking changes as this plugin evolves.


### PR DESCRIPTION
The current installation instructions yield a syntax error. Fixed `vim-plug` installation line to match the examples in the [vim-plug docs](https://github.com/junegunn/vim-plug).