### PR TITLE
fix: Ensure terminals are deleted correctly when multiple open

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -9,7 +9,6 @@ local config = lazy.require("toggleterm.config")
 local utils = lazy.require("toggleterm.utils")
 ---@module "toggleterm.constants"
 local constants = lazy.require("toggleterm.constants")
-local AUGROUP = "ToggleTermBuffer"
 
 local api = vim.api
 local fmt = string.format
@@ -20,6 +19,8 @@ local mode = {
   NORMAL = "n",
   UNSUPPORTED = "?",
 }
+
+local AUGROUP = api.nvim_create_augroup("ToggleTermBuffer", { clear = true })
 
 local is_windows = fn.has("win32") == 1
 local function is_cmd(shell) return string.find(shell, "cmd") end
@@ -119,7 +120,6 @@ end
 ---@param term Terminal
 local function setup_buffer_autocommands(term)
   local conf = config.get()
-  api.nvim_create_augroup(AUGROUP, { clear = true })
   api.nvim_create_autocmd("TermClose", {
     buffer = term.bufnr,
     group = AUGROUP,


### PR DESCRIPTION
When a terminal is opened an `autocmd` is attached to the given terminal buffer to delete the terminal from the in-memory register. This becomes a problem when multiple terminals are opened as previously created auto commands are replaced by subsequent creations, meaning only the last terminals reference will be removed when it is closed, all others will remain.

Rather than relying on multiple `autocmd`s which have closure over the terminals they need to close, this PR uses a single command which uses the buffer number from the callback to locate the terminal which needs to be deleted. My neovim/lua knowledge isn't the best so feel free to edit if you have a better solution.

My motivation for wanting this behaviour is that I use sessions to switch between projects. If I have multiple terminals open within one project/session, when switching sessions, all terminal buffers will be closed but not all of them will be removed from memory. Then, when I open a new terminal in the new session, the previous terminal references are used and therefore retain the previous directory.
