### PR TITLE
fix: don't try to close the last tab

### DIFF
--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -314,7 +314,12 @@ function M.open_tab(term)
   create_term_buf_if_needed(term)
 end
 
-local function close_tab() vim.cmd("tabclose") end
+local function close_tab()
+  local tab = vim.api.nvim_list_tabpages()
+  if #tab > 1 then
+    vim.cmd([[tabclose]])
+  end
+end
 
 ---Close terminal window
 ---@param term Terminal


### PR DESCRIPTION
running `:toggleterm` when terminal is only opened tab results in
```Error executing Lua callback: .../pack/packer/start/toggleterm.nvim/lua/toggleterm/ui.lua:317: Vim(tabclose):E784: Cannot close last tab page
stack traceback:
        [C]: in function 'cmd'
        .../pack/packer/start/toggleterm.nvim/lua/toggleterm/ui.lua:317: in function 'close_tab'
        .../pack/packer/start/toggleterm.nvim/lua/toggleterm/ui.lua:361: in function 'close'
        ...packer/start/toggleterm.nvim/lua/toggleterm/terminal.lua:253: in function 'close'
        ...ite/pack/packer/start/toggleterm.nvim/lua/toggleterm.lua:82: in function 'smart_toggle'
        ...ite/pack/packer/start/toggleterm.nvim/lua/toggleterm.lua:342: in function 'toggle'
        ...ite/pack/packer/start/toggleterm.nvim/lua/toggleterm.lua:315: in function 'toggle_command'
        ...ite/pack/packer/start/toggleterm.nvim/lua/toggleterm.lua:432: in function <...ite/pack/packer/start/toggleterm.nvim/lua/toggleterm.lua:432>```