### PR TITLE
style: add colon to terminal selection prompt

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -343,7 +343,7 @@ local function get_subject_terminal(callback)
   if #items == 0 then return utils.notify("No toggleterms are open yet") end
 
   vim.ui.select(items, {
-    prompt = "Please select a terminal to name",
+    prompt = "Please select a terminal to name: ",
     format_item = function(term) return term.id .. ": " .. term:_display_name() end,
   }, function(term)
     if not term then return end


### PR DESCRIPTION
This is so [fzf-lua](https://github.com/ibhagwan/fzf-lua)'s selection menu can properly override the prompt suffix.

https://github.com/ibhagwan/fzf-lua/blob/0944e1e/lua/fzf-lua/providers/ui_select.lua#L90
```lua
    ['--prompt']          = prompt:gsub(":%s?$", "> "),
```