### PR TITLE
fix(ui): check all tabs for current terminal's window

### DIFF
--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -142,6 +142,7 @@ show what options are available. It is not written to be used as is.
       on_exit = fun(t: Terminal, job: number, exit_code: number, name: string) -- function to run when terminal process exits
       hide_numbers = true, -- hide the number column in toggleterm buffers
       shade_filetypes = {},
+      autochdir = false, -- when neovim changes it current directory the terminal will change it's own when next it's opened
       highlights = {
         -- highlights which map to a highlight group name and a table of it's values
         -- NOTE: this is only a subset of values, any group placed here will be set for the terminal window split

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -55,17 +55,12 @@ local function smart_toggle(_, size, dir, direction)
     -- Re-open the first terminal toggled
     terms.get_or_create_term(terms.get_toggled_id(), dir, direction):open(size, direction)
   else
-    local target
     -- count backwards from the end of the list
     for i = #terminals, 1, -1 do
       local term = terminals[i]
-      if term and ui.term_has_open_win(term) then
-        target = term
-        break
-      end
+      if term and ui.term_has_open_win(term) then return term:close() end
     end
-    if not target then return utils.notify("Couldn't find a terminal to close", "error") end
-    target:close()
+    utils.notify("Couldn't find a terminal to close", "error")
   end
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -212,6 +212,8 @@ function Terminal:is_split()
     and not ui.is_float(self.window)
 end
 
+function Terminal:is_tab() return self.direction == "tab" and not ui.is_float(self.window) end
+
 function Terminal:resize(size)
   if self:is_split() then ui.resize_split(self, size) end
 end

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -183,7 +183,8 @@ end
 function M.find_open_windows(comparator)
   comparator = comparator or default_compare
   local term_wins, is_open = {}, false
-  for _, win in pairs(api.nvim_list_wins()) do
+  -- only check the current tab page for open terminals
+  for _, win in pairs(api.nvim_tabpage_list_wins(api.nvim_get_current_tabpage())) do
     if comparator(api.nvim_win_get_buf(win)) then
       is_open = true
       table.insert(term_wins, win)
@@ -377,8 +378,11 @@ function M.find_windows_by_bufnr(bufnr) return fn.win_findbuf(bufnr) end
 ---@return boolean
 function M.term_has_open_win(term)
   if not term.window then return false end
-  local open_wins = api.nvim_tabpage_list_wins(api.nvim_get_current_tabpage())
-  return vim.tbl_contains(open_wins, term.window)
+  local wins = {}
+  for _, tab in ipairs(api.nvim_list_tabpages()) do
+    vim.list_extend(wins, api.nvim_tabpage_list_wins(tab))
+  end
+  return vim.tbl_contains(wins, term.window)
 end
 
 return M


### PR DESCRIPTION
When seeing if the terminal is toggled open, but only check current win for the current terminals windows when finding windows to see if any terminals are open.