### PR TITLE
docs(README): change cmd on closing the terminal in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ local lazygit = Terminal:new({
   end,
   -- function to run on closing the terminal
   on_close = function(term)
-    vim.cmd("Closing terminal")
+    vim.cmd("startinsert!")
   end,
 })
 


### PR DESCRIPTION
"Closing terminal" is not a valid cmd command.