### PR TITLE
docs(README): add example mapping for wincmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ function _G.set_terminal_keymaps()
   vim.keymap.set('t', '<C-j>', [[<Cmd>wincmd j<CR>]], opts)
   vim.keymap.set('t', '<C-k>', [[<Cmd>wincmd k<CR>]], opts)
   vim.keymap.set('t', '<C-l>', [[<Cmd>wincmd l<CR>]], opts)
+  vim.keymap.set('t', '<C-w>', [[<C-\><C-n><C-w>]], opts)
 end
 
 -- if you only want these mappings for toggle term use term://*toggleterm#* instead


### PR DESCRIPTION
With the terminal being in `TERM (INSERT)` mode by default, I sometimes get stuck trying to switch away from it. When I leave it open, I often use `Ctrl-w {w/h/j/k/l}` to jump in and out of it, as between other windows. It's however not as functionally or visually apparent that I'm stuck in `TERM` mode when this fails (the term cursor remaining a block may play a role).

This change switches to `Ctrl-w` in `TERM` mode and awaits the direction key. I think it complements the existing bindings well, for a more natural experience. 