### PR TITLE
feat: enable switching to the next and previous float terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ You can map this to a key and call it with a count, which will then prompt you a
 Alternatively you can call it with just the name e.g. `:ToggleTermSetName work<CR>` this will the prompt you for which terminal it should apply to.
 Lastly you can call it without any arguments, and it will prompt you for which terminal it should apply to then prompt you for the name to use.
 
+### ToggleTermFloatNext/ToggleTermFloatPrev
+
+This functions allow you to switch the terminals by cycling through them when you are in a float one.
+
 ### Set terminal shading
 
 This plugin automatically shades terminal filetypes to be darker than other window

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -70,6 +70,37 @@ local function smart_toggle(_, size, dir, direction)
   end
 end
 
+---@param terminal_chooser fun(terminal_index: number, terminals_size: number)
+function M.neighbor_float_term(terminal_chooser)
+    if not ui.find_open_windows() then return end
+
+    local terminals = terms.get_all()
+    local focused_term_index
+    for index, terminal in ipairs(terminals) do
+        if terminal:is_focused() then focused_term_index = index end
+    end
+
+    local focused_term = terminals[focused_term_index]
+    if not focused_term:is_float() then return end
+
+    if not focused_term_index then return end
+    local next_terminal_index = terminal_chooser(focused_term_index, #terminals)
+
+    local next_terminal = terminals[next_terminal_index]
+
+    focused_term:close()
+    terms.get_or_create_term(next_terminal.id):open()
+end
+
+function M.prev_float_term()
+    M.neighbor_float_term(function(focused_index, terminals_number) return focused_index == 1 and terminals_number or focused_index - 1 end)
+end
+
+function M.next_float_term()
+    M.neighbor_float_term(function(focused_index, terminals_number) return focused_index == terminals_number and 1 or focused_index + 1 end)
+end
+
+
 --- @param num number
 --- @param size number?
 --- @param dir string?
@@ -397,6 +428,16 @@ local function setup_commands()
     function(args) M.send_lines_to_terminal("single_line", true, args) end,
     { nargs = "?" }
   )
+
+  cmd(
+      "ToggleTermFloatNext",
+      function() M.next_float_term() end,
+      {})
+
+  cmd(
+      "ToggleTermFloatPrev",
+      function() M.prev_float_term() end,
+      {})
 
   cmd("ToggleTermSetName", function(opts)
     local no_count = not opts.count or opts.count < 1


### PR DESCRIPTION
### TL;DR
Introducing of **ToggleTermFloatNext/ToggleTermFloatPrev** commands for the `float` terminals. Just switching to the next/previous terminal id from the list in a cycled manner.


### Motivation
Since I usually use `float` windows for the terminals, in my flow I'm missing the feature of "switching to the previous/next terminal".

E.g. It's common for me to have 3 terminals at the same time, and switching between them with the `count` feature is not very convenient, as I have to keep in mind some kind of mapping of the terminal number to its actual state. I'd like to switch between them just by going forward/backward

After Neovim 0.9 release and together with this feature (https://github.com/akinsho/toggleterm.nvim/issues/363) process of switching will become even more transparent for the user.

It's my first experience in Lua/Neovim development, so don't judge me too much, I will be happy to fix any notes and issues :)