### PR TITLE
docs(README): change comment for `shading_factor` key in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ require("toggleterm").setup{
     },
   },
   shade_terminals = true, -- NOTE: this option takes priority over highlights specified so if you specify Normal highlights you should set this to false
-  shading_factor = '<number>', -- the degree by which to darken to terminal colour, default: 1 for dark backgrounds, 3 for light
+  shading_factor = '<number>', -- the percentage by which to lighten terminal background, default: -30 (gets mutliplied by -3 if background is light)
   start_in_insert = true,
   insert_mappings = true, -- whether or not the open mapping applies in insert mode
   terminal_mappings = true, -- whether or not the open mapping applies in the opened terminals

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ require("toggleterm").setup{
     },
   },
   shade_terminals = true, -- NOTE: this option takes priority over highlights specified so if you specify Normal highlights you should set this to false
-  shading_factor = '<number>', -- the percentage by which to lighten terminal background, default: -30 (gets mutliplied by -3 if background is light)
+  shading_factor = '<number>', -- the percentage by which to lighten terminal background, default: -30 (gets multiplied by -3 if background is light)
   start_in_insert = true,
   insert_mappings = true, -- whether or not the open mapping applies in insert mode
   terminal_mappings = true, -- whether or not the open mapping applies in the opened terminals


### PR DESCRIPTION
I thinks this comment describes what the key is for better, the other comment was misleading. This comment also has the correct default value.