### PR TITLE
fix: add missing self:on_create() to Terminal:spawn()

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -445,6 +445,7 @@ function Terminal:spawn()
     api.nvim_buf_call(self.bufnr, function() self:__spawn() end)
     setup_buffer_autocommands(self)
     setup_buffer_mappings(self.bufnr)
+    if self.on_create then self:on_create() end
   end
 end
 


### PR DESCRIPTION
Currently the `on_create` callback is not being called when creating a task using `Terminal:spawn()` instead of `Terminal:open()`. 