### PR TITLE
doc(README): fix vim plug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Using vim-plug in vimscript
 
 ```vim
 Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
+
+lua require("toggleterm").setup()
 ```
 
 You can/should specify a tag for the current major version of the plugin, to avoid breaking changes as this plugin evolves.


### PR DESCRIPTION
I think that this PR would avoid problems like those:
![image](https://user-images.githubusercontent.com/50843046/216387601-e10bd929-8008-4cb5-abf4-32883c7ca821.png)

[Here](https://vi.stackexchange.com/questions/39967/cannot-open-terminal-ini-nvim/39968?noredirect=1#comment73213_39968)'s the vim question.