### PR TITLE
horizontal split with respect to sidebar plugin

### DIFF
--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -291,7 +291,11 @@ function M.open_split(size, term)
     api.nvim_set_current_win(split_win)
     vim.cmd(commands.existing)
   else
-    vim.cmd(commands.new)
+    if term.direction == "horizontal" then
+      vim.cmd("split | resize " .. config.size .. " | wincmd p")
+    else
+      vim.cmd(commands.new)
+    end
   end
 
   M.resize_split(term, size)


### PR DESCRIPTION
Hi,

I find the way `toggleterm` currently splits window horizontally a bit strange, it splits an area underneath all windows, which includes plug-ins like sidebar (`nvimtree`, `tagbar` etc.), but this is not how the terminal behaves in other IDE.

I have seen similar issues (#97 #359 ) and perhaps it would be worthwhile to add such an option.

Here is my solution, I can add an option to the `config.lua` to avoid breaking change if you would like to accept this PR.