### PR TITLE
feat: open last toggled term on smart toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ I'm also going to be pretty conservative about what I add.
 
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
-Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode
-If you prefix the mapping with a number that particular terminal will be opened.
+Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode.
+If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened.
 
 If you set the `insert_mappings` key to true, the mapping will also take effect in insert mode; similarly setting `terminal_mappings` to will have the mappings take effect in the opened terminal.
 

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -93,8 +93,9 @@ SETUP ~
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
 Setting the `open_mapping` key to use for toggling the terminal(s) will set up
-mappings for _normal_ mode If you prefix the mapping with a number that
-particular terminal will be opened.
+mappings for _normal_ mode. If you prefix the mapping with a number that
+particular terminal will be opened; Otherwise if a prefix is not set, then the
+last toggled terminal will be opened.
 
 If you set the `insert_mappings` key to true, the mapping will also take effect
 in insert mode; similarly setting `terminal_mappings` to will have the mappings

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -58,8 +58,9 @@ end
 local function smart_toggle(_, size, dir, direction)
   local terminals = terms.get_all()
   if not ui.find_open_windows() then
-    -- Re-open the first terminal toggled
-    terms.get_or_create_term(terms.get_toggled_id(), dir, direction):open(size, direction)
+    -- Re-open the last terminal used (if exists) or the first terminal toggled.
+    local term_id = terms.get_last_toggled_id() or terms.get_toggled_id()
+    terms.get_or_create_term(term_id, dir, direction):open(size, direction)
   else
     -- count backwards from the end of the list
     for i = #terminals, 1, -1 do

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -44,6 +44,8 @@ end
 ---@type Terminal[]
 local terminals = {}
 
+local last_toggled_id = nil
+
 --- @class TermCreateArgs
 --- @field cmd string
 --- @field direction? string the layout style for the terminal
@@ -112,6 +114,10 @@ function M.get_toggled_id(position)
   local t = M.get_all()
   return t[position] and t[position].id or nil
 end
+
+---Get a last toggled (opened or closed) terminal id.
+---@return number?
+function M.get_last_toggled_id() return last_toggled_id end
 
 --- @param bufnr number
 local function setup_buffer_mappings(bufnr)
@@ -263,6 +269,7 @@ function Terminal:close()
   ui.close(self)
   ui.stopinsert()
   ui.update_origin_window(self.window)
+  last_toggled_id = self.id
 end
 
 function Terminal:shutdown()

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -156,6 +156,18 @@ describe("ToggleTerm tests:", function()
       assert.is_true(ui.term_has_open_win(term))
     end)
 
+    it("should open the last toggled terminal", function()
+      local term1 = Terminal:new({ count = 1 }):toggle()
+      term1:close()
+      local term2 = Terminal:new({ count = 2 }):toggle()
+      term2:close()
+
+      toggleterm.toggle(0)
+
+      assert.is_true(ui.term_has_open_win(term2))
+      assert.is_false(ui.term_has_open_win(term1))
+    end)
+
     it("should open a hidden terminal and a visible one", function()
       local hidden = Terminal:new({ hidden = true }):toggle()
       local visible = Terminal:new():toggle()


### PR DESCRIPTION
I find myself often wanting to open last used (toggled) terminal with the open mapping, as it feels natural to continue where you left off. Right now the first toggled terminal will be opened instead, which usually makes me re-think where I left and then I have to toggle that specific terminal that I've used.

This PR adds logic to `smart_toggle` to open last toggled terminal if none are opened, instaed of openning the first one. The changes are minimal, and I feel it doesn't complicate the code much. @akinsho  let me know what you think :)
