### PR TITLE
feat: restore terminal view on smart toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ I'm also going to be pretty conservative about what I add.
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
 Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode.
-If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened.
+If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened. In case there are multiple terminals opened they'll all be closed, and on the next mapping key they'll be restored.
 
 If you set the `insert_mappings` key to true, the mapping will also take effect in insert mode; similarly setting `terminal_mappings` to will have the mappings take effect in the opened terminal.
 

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -95,7 +95,8 @@ This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 Setting the `open_mapping` key to use for toggling the terminal(s) will set up
 mappings for _normal_ mode. If you prefix the mapping with a number that
 particular terminal will be opened. Otherwise if a prefix is not set, then the
-last toggled terminal will be opened.
+last toggled terminal will be opened. In case there are multiple terminals
+opened they'll all be closed, and on the next mapping key they'll be restored.
 
 If you set the `insert_mappings` key to true, the mapping will also take effect
 in insert mode; similarly setting `terminal_mappings` to will have the mappings

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -44,8 +44,6 @@ end
 ---@type Terminal[]
 local terminals = {}
 
-local last_toggled_id = nil
-
 --- @class TermCreateArgs
 --- @field cmd string
 --- @field direction? string the layout style for the terminal
@@ -115,9 +113,14 @@ function M.get_toggled_id(position)
   return t[position] and t[position].id or nil
 end
 
----Get a last toggled (opened or closed) terminal id.
+---Return currently focused terminal id.
 ---@return number?
-function M.get_last_toggled_id() return last_toggled_id end
+function M.get_focused_id()
+  for _, term in pairs(terminals) do
+    if term:is_focused() then return term.id end
+  end
+  return nil
+end
 
 --- @param bufnr number
 local function setup_buffer_mappings(bufnr)
@@ -269,7 +272,6 @@ function Terminal:close()
   ui.close(self)
   ui.stopinsert()
   ui.update_origin_window(self.window)
-  last_toggled_id = self.id
 end
 
 function Terminal:shutdown()


### PR DESCRIPTION
A continuation of #397 where the idea is taken a bit further, and a complete terminal view is being toggled instead of just the last toggled terminal. When working with the terminals you often want to save your complete view that you've been working on, instead of just closing terminals one by one, and opening them up (again) one by one. There's already a utility mapping that let's you open and close all of your terminals, but this doesn't take into consideration what was previously opened. Therefore to make `smart_toggle` even smarter we could save the current terminal view, and then open it up the next time it is triggered.

In order to achieve this functionality we could keep a list of terminals that were closed, and use it to go over the list to open them on next smart toggle.
