### PR TITLE
docs(README): fix arg typos in the lazy installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim) in lua
 ```lua
 {
   -- amongst your other plugins
-  {'akinsho/toggleterm.nvim', tag = "*", config = true}
+  {'akinsho/toggleterm.nvim', version = "*", config = true}
   -- or
-  {'akinsho/toggleterm.nvim', tag = "*", opts = {--[[ things you want to change go here]]}}
+  {'akinsho/toggleterm.nvim', version = "*", opts = {--[[ things you want to change go here]]}}
 }
 ```
 


### PR DESCRIPTION
Just a quick fix as per stated in https://github.com/folke/lazy.nvim/blob/8077428e63feb0f3bf795d53b23ba1695b28ab0e/README.md?plain=1#L693