### PR TITLE
features/add-float-titles

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -44,13 +44,23 @@ end
 ---@type Terminal[]
 local terminals = {}
 
+---@class FloatOpts
+---@field border string | string[]
+---@field title string | fun(count: integer, term: Terminal): string
+---@field width integer
+---@field height integer
+---@field row integer
+---@field col integer
+---@field relative boolean
+---@field winblend integer
+
 --- @class TermCreateArgs
 --- @field cmd string
 --- @field direction? string the layout style for the terminal
 --- @field id number?
 --- @field highlights table<string, table<string, string>>?
 --- @field dir string? the directory for the terminal
---- @field count number? the count that triggers that specific terminal
+--- @field count integer? the count that triggers that specific terminal
 --- @field display_name string?
 --- @field hidden boolean? whether or not to include this terminal in the terminals list
 --- @field close_on_exit boolean? whether or not to close the terminal window when the process exits
@@ -77,7 +87,7 @@ local terminals = {}
 --- @field hidden boolean whether or not to include this terminal in the terminals list
 --- @field close_on_exit boolean? whether or not to close the terminal window when the process exits
 --- @field auto_scroll boolean? whether or not to scroll down on terminal output
---- @field float_opts table<string, any>?
+--- @field float_opts FloatOpts?
 --- @field display_name string?
 --- @field env table<string, string> environmental variables passed to jobstart()
 --- @field clear_env boolean use clean job environment, passed to jobstart()
@@ -267,7 +277,11 @@ function Terminal:persist_mode()
   self.__state.mode = m
 end
 
----@package
+function Terminal:float_title()
+  local count = #M.get_all(true)
+  return fmt(" toggleterm (%d/%d) ", self.id, count + 1)
+end
+
 function Terminal:_display_name() return self.display_name or vim.split(self.name, ";")[1] end
 
 function Terminal:close()

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -295,7 +295,7 @@ function M._get_float_config(term, opening)
     height = height,
     border = opening and border or nil,
   }
-  if vim.version().minor >= 0.9 then win_opts.title = term:float_title() end
+  if utils.is_nightly() then win_opts.title = term:float_title() end
   return win_opts
 end
 

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -286,7 +286,7 @@ function M._get_float_config(term, opening)
   row = vim.F.if_nil(M._resolve_size(opts.row, term), row)
   col = vim.F.if_nil(M._resolve_size(opts.col, term), col)
 
-  return {
+  local win_opts = {
     row = row,
     col = col,
     relative = opts.relative or "editor",
@@ -295,6 +295,8 @@ function M._get_float_config(term, opening)
     height = height,
     border = opening and border or nil,
   }
+  if vim.version().minor >= 0.9 then win_opts.title = term:float_title() end
+  return win_opts
 end
 
 --- @param size number

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -78,9 +78,9 @@ local hl_end = "%*"
 ---@param id number
 ---@return string
 function M.winbar(id)
-  local terms = require("toggleterm.terminal").get_all()
+  local terminals = require("toggleterm.terminal").get_all()
   local str = " "
-  for _, t in pairs(terms) do
+  for _, t in pairs(terminals) do
     local h = id == t.id and "WinBarActive" or "WinBarInactive"
     str = str
       .. fmt("%%%d@v:lua.___toggleterm_winbar_click@", t.id)

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -6,7 +6,7 @@ local levels = vim.log.levels
 
 function M.is_nightly()
   local v = vim.version()
-  return v.minor >= 8
+  return v.minor >= 9
 end
 
 ---@alias error_types 'error' | 'info' | 'warn'


### PR DESCRIPTION
Not sure what shape this should take yet/what is actually valuable here. This will be user configurable but by default the idea is to show the terminal ID, I see floatterm shows a count and this was partially inspired by #363 by actually think this might be a bit pointless (IMO). Why is it useful to know that this is terminal 1/5 or 3/7? what do you do with that information? cc @Blackmorse you originally raised that issue and might be interested in testing this out.