### PR TITLE
Add option to quote the command sent to the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ require("toggleterm").setup{
   direction = 'vertical' | 'horizontal' | 'tab' | 'float',
   close_on_exit = true, -- close the terminal window when the process exits
   shell = vim.o.shell, -- change the default shell
+  quote_command = false, -- put quotes arround the command sent to the terminal, required for Windows using git bash
   auto_scroll = true, -- automatically scroll to the bottom on terminal output
   -- This field is only relevant if direction is set to 'float'
   float_opts = {

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -185,6 +185,7 @@ show what options are available. It is not written to be used as is.
       direction = 'vertical' | 'horizontal' | 'tab' | 'float',
       close_on_exit = true, -- close the terminal window when the process exits
       shell = vim.o.shell, -- change the default shell
+      quote_command = false -- put quotes around the command being sent to the terminal. Required for Windows using git bash
       auto_scroll = true, -- automatically scroll to the bottom on terminal output
       -- This field is only relevant if direction is set to 'float'
       float_opts = {

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -50,6 +50,7 @@ local config = {
   direction = "horizontal",
   shading_factor = constants.shading_amount,
   shell = vim.o.shell,
+  quote_command = false,
   autochdir = false,
   auto_scroll = true,
   winbar = {

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -375,13 +375,16 @@ function Terminal:__spawn()
   local cmd = self.cmd or config.get("shell")
   local command_sep = get_command_sep()
   local comment_sep = get_comment_sep()
+  local quote = config.get("quote_command") and "\"" or ""
   cmd = table.concat({
+    quote,
     cmd,
     command_sep,
     comment_sep,
     constants.FILETYPE,
     comment_sep,
     self.id,
+    quote,
   })
   local dir = _get_dir(self.dir)
   self.job_id = fn.termopen(cmd, {


### PR DESCRIPTION
This added setting is ment to put the command sent to the terminal buffer in quote. This is for compatibility with git bash in Windows where the way neovim sends the command is using `bash -c <cmd>` without putting the whole command in quotes errors are raised due to `unknown command`.

I tested this new process under my work windows machine. Toggleterm is now able to open the terminal without problem. Even custom terminals.

I did some regression test on my linux desktop and without providing the new `quote_command`. The behavior stayed the same.