### PR TITLE
feat: support z-index option for floating windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ require("toggleterm").setup{
     width = <value>,
     height = <value>,
     winblend = 3,
+    zindex = <value>,
   },
   winbar = {
     enabled = false,

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -197,6 +197,7 @@ show what options are available. It is not written to be used as is.
         width = <value>,
         height = <value>,
         winblend = 3,
+        zindex = <value>,
       },
       winbar = {
         enabled = false,

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -294,6 +294,7 @@ function M._get_float_config(term, opening)
     width = width,
     height = height,
     border = opening and border or nil,
+    zindex = opts.zindex or nil,
   }
 end
 


### PR DESCRIPTION
When using toggleterm and [incline](https://github.com/b0o/incline.nvim) together, this change allows the user to give toggleterm a higher zindex than incline to prevent undesired overlapping.