### PR TITLE
feat: add a terminal select command

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ You can send commands to a terminal without opening its window by using the `ope
 
 see `:h expand()` for more details
 
+### TermSelect
+
+This command uses `vim.ui.select` to allow a user to select a terminal to open
+or to focus if it's already open. This can be useful if you have a lot of
+terminals and want to open a specific one
+
 ### Sending lines to the terminal
 
 You can "send lines" to the toggled terminals with the following commands:

--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ see `:h expand()` for more details
 ### TermSelect
 
 This command uses `vim.ui.select` to allow a user to select a terminal to open
-or to focus if it's already open. This can be useful if you have a lot of
-terminals and want to open a specific one
+or to focus it if it's already open. This can be useful if you have a lot of
+terminals and want to open a specific one.
 
 ### Sending lines to the terminal
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -310,9 +310,7 @@ end
 ---@param cmd string|string[]
 ---@param go_back boolean? whether or not to return to original window
 function Terminal:send(cmd, go_back)
-  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(
-      cmd --[[@as string]]
-    )
+  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(cmd --[[@as string]])
   fn.chansend(self.job_id, cmd)
   self:scroll_bottom()
   if go_back and self:is_focused() then

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -310,7 +310,9 @@ end
 ---@param cmd string|string[]
 ---@param go_back boolean? whether or not to return to original window
 function Terminal:send(cmd, go_back)
-  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(cmd --[[@as string]])
+  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(
+      cmd --[[@as string]]
+    )
   fn.chansend(self.job_id, cmd)
   self:scroll_bottom()
   if go_back and self:is_focused() then

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -321,7 +321,7 @@ describe("ToggleTerm tests:", function()
     end)
 
     it("should execute the same regardless whether shell is a string or a function", function()
-      toggleterm.setup { shell = function() return vim.o.shell end }
+      toggleterm.setup({ shell = function() return vim.o.shell end })
       local test1 = Terminal:new():toggle()
       local _ = match._
       spy.on(test1, "send")


### PR DESCRIPTION
This PR adds a `TerminalSelect` command which uses `vim.ui.select` to allow the user to choose which terminal to open or focus