### PR TITLE
fix: replace vim.wo with nvim_set_option_value

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -415,15 +415,14 @@ end
 
 ---@package
 function Terminal:__set_win_options()
-  local win = vim.wo[self.window]
   if self:is_split() then
     local field = self.direction == "vertical" and "winfixwidth" or "winfixheight"
-    win[field] = true
+    vim.api.nvim_set_option_value(field, true, { scope = "local", win = self.window })
   end
 
   if config.hide_numbers then
-    win.number = false
-    win.relativenumber = false
+    vim.api.nvim_set_option_value("number", false, { scope = "local", win = self.window })
+    vim.api.nvim_set_option_value("relativenumber", false, { scope = "local", win = self.window })
   end
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -417,12 +417,12 @@ end
 function Terminal:__set_win_options()
   if self:is_split() then
     local field = self.direction == "vertical" and "winfixwidth" or "winfixheight"
-    vim.api.nvim_set_option_value(field, true, { scope = "local", win = self.window })
+    utils.wo_setlocal(self.window, field, true)
   end
 
   if config.hide_numbers then
-    vim.api.nvim_set_option_value("number", false, { scope = "local", win = self.window })
-    vim.api.nvim_set_option_value("relativenumber", false, { scope = "local", win = self.window })
+    utils.wo_setlocal(self.window, "number", false)
+    utils.wo_setlocal(self.window, "relativenumber", false)
   end
 end
 

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -139,7 +139,11 @@ function M.hl_term(term)
     return hi_target
   end, hl_names)
 
-  vim.wo[window].winhighlight = table.concat(highlights, ",")
+  vim.api.nvim_set_option_value(
+    "winhighlight",
+    table.concat(highlights, ","),
+    { scope = "local", win = window }
+  )
 end
 
 ---Create a terminal buffer with the correct buffer/window options
@@ -151,13 +155,11 @@ local function create_term_buf_if_needed(term)
   -- If the buffer doesn't exist create a new one
   local valid_buf = term.bufnr and api.nvim_buf_is_valid(term.bufnr)
   local bufnr = valid_buf and term.bufnr or api.nvim_create_buf(false, false)
-
+  -- Assign buf to window to ensure window options are set correctly
+  api.nvim_win_set_buf(window, bufnr)
   term.window, term.bufnr = window, bufnr
   term:__set_options()
-  if valid_buf then return end
-  -- If the buffer didn't previously exist then assign it the window
   api.nvim_set_current_buf(bufnr)
-  api.nvim_win_set_buf(window, bufnr)
 end
 
 function M.create_buf() return api.nvim_create_buf(false, false) end
@@ -365,7 +367,9 @@ function M.open_float(term)
   -- partial fix for #391
   vim.wo[win].sidescrolloff = 0
 
-  if opts.winblend then vim.wo[win].winblend = opts.winblend end
+  if opts.winblend then
+    vim.api.nvim_set_option_value("winblend", opts.winblend, { scope = "local", win = win })
+  end
   term:__set_options()
 end
 

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -104,7 +104,8 @@ function M.set_winbar(term)
   then
     return
   end
-  vim.wo[term.window].winbar = fmt('%%{%%v:lua.require("toggleterm.ui").winbar(%d)%%}', term.id)
+  local value = fmt('%%{%%v:lua.require("toggleterm.ui").winbar(%d)%%}', term.id)
+  utils.wo_setlocal(term.window, "winbar", value)
 end
 
 ---apply highlights to a terminal
@@ -139,11 +140,7 @@ function M.hl_term(term)
     return hi_target
   end, hl_names)
 
-  vim.api.nvim_set_option_value(
-    "winhighlight",
-    table.concat(highlights, ","),
-    { scope = "local", win = window }
-  )
+  utils.wo_setlocal(window, "winhighlight", table.concat(highlights, ","))
 end
 
 ---Create a terminal buffer with the correct buffer/window options
@@ -365,11 +362,9 @@ function M.open_float(term)
 
   term.window, term.bufnr = win, buf
   -- partial fix for #391
-  vim.wo[win].sidescrolloff = 0
+  utils.wo_setlocal(win, "sidescrolloff", 0)
 
-  if opts.winblend then
-    vim.api.nvim_set_option_value("winblend", opts.winblend, { scope = "local", win = win })
-  end
+  if opts.winblend then utils.wo_setlocal(win, "winblend", opts.winblend) end
   term:__set_options()
 end
 

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -100,4 +100,13 @@ function M.get_visual_selection(res)
   end
 end
 
+--- Sets a local window option, like `:setlocal`
+--- TODO: replace with double-indexing on `vim.wo` when neovim/neovim#20288 (hopefully) merges
+---@param win number
+---@param option string
+---@param value any
+function M.wo_setlocal(win, option, value)
+  api.nvim_set_option_value(option, value, { scope = "local", win = win })
+end
+
 return M


### PR DESCRIPTION
I recently discovered [stickybuf.nvim](https://github.com/stevearc/stickybuf.nvim), and it's great at preventing buffers from opening inside plugin windows, ToggleTerm included.

However, due to the way ToggleTerm sets its window options, if I accidentally/intentionally open a new file while in the ToggleTerm buffer, the new buffer inherits ToggleTerm's window options (specifically `winhighlight`, `nonumber` and `norelativenumber` for my config). This means that when stickybuf moves that buffer to a different window, it keeps those window options and thus has a dark background and no line numbers. The same kind of thing also happens without stickybuf, but opening buffers inside ToggleTerm's window causes some other glitchy behaviour if you immediately then try and open ToggleTerm using the keybinding again, which is sort of to be expected.

The root cause is the use of `vim.wo` to set window options, which behaves counter-intuitively (in my opinion): see https://github.com/folke/lazy.nvim/issues/829 and https://github.com/neovim/neovim/issues/14595. For window-local options, `vim.wo` sets both the global and local values of the option, like `:set` does. This is different to what I would have expected, which is what `vim.bo` does - it only sets the local value for buffer-local options, like `:setlocal` does. For global-local options, `vim.wo` and `vim.bo` both do the same and act like `:setlocal`, only setting the local value of the option.

This therefore replaces all uses of `vim.wo` to set window-local options with `nvim_set_option_value`, so that only the local value is set, meaning that new buffers created in the ToggleTerm window will not inherit those options. I haven't changed the lines where `winbar` or `sidescrolloff` are set, since those are global-local options and thus `vim.wo` works as expected. Those can also easily be changed for consistency if needed.

I also haven't changed any uses of `vim.wo` to get option values (in tests), since that also works as expected as far as I can tell.