### PR TITLE
refactor(terminal): re-use spawn function

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -393,6 +393,8 @@ function Terminal:__spawn()
   })
   self.name = cmd
   self.dir = dir
+  setup_buffer_autocommands(self)
+  setup_buffer_mappings(self.bufnr)
 end
 
 ---@package
@@ -454,8 +456,6 @@ function Terminal:spawn()
     self.bufnr = ui.create_buf()
     self:__add()
     api.nvim_buf_call(self.bufnr, function() self:__spawn() end)
-    setup_buffer_autocommands(self)
-    setup_buffer_mappings(self.bufnr)
     if self.on_create then self:on_create() end
   end
 end


### PR DESCRIPTION
Refactors the `open` function to re-use spawn rather than essentially re-implement it.