### PR TITLE
fix: TermExec cmd with config.shell = function

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -33,6 +33,7 @@ local function get_comment_sep() return is_windows and is_cmd(vim.o.shell) and "
 
 local function get_newline_chr()
   local shell = config.get("shell")
+  if type(shell) == "function" then shell = shell() end
   return is_windows and (is_pwsh(shell) and "\r" or "\r\n") or "\n"
 end
 


### PR DESCRIPTION
fixes(#466)

This minor change personally resolves the issue I was facing, although potentially there might be other instances in the code where the shell option is assumed to be a string, I have not looked through the codebase for other occurrences though.  