### PR TITLE
feat: add name param to ToggleTerm and TermExec

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ require("toggleterm").setup{
 
 This is the command the mappings call under the hood. You can use it directly
 and prefix it with a count to target a specific terminal. This function also takes
-arguments `size`, `dir` and `direction`. e.g.
+arguments `size`, `dir`, `direction` and `name`. e.g.
 
 ```vim
-:ToggleTerm size=40 dir=~/Desktop direction=horizontal
+:ToggleTerm size=40 dir=~/Desktop direction=horizontal name=desktop
 ```
 
 If `dir` is specified on creation toggle term will open at the specified directory.
@@ -243,6 +243,9 @@ the height/width of all terminals in the same direction will be changed to `size
 
 If `direction` is specified, and the command opens a terminal,
 the terminal will be changed to the specified direction.
+
+If `name` is specified, the display name is set for the toggled terminal. This name will be visible
+when using `TermSelect` command to indicate the specific terminal.
 
 `size` and `direction` are ignored if the command closes a terminal.
 
@@ -268,7 +271,7 @@ The `cmd` and `dir` arguments can also expand the same special keywords as `:h e
 
 These special keywords can be escaped using the `\` character, if you want to print character as is.
 
-The `size` and `direction` arguments are like the `size` and `direction` arguments of `ToggleTerm`.
+The `size`, `direction` and `name` arguments are like the `size`, `direction` and `name` arguments of `ToggleTerm`.
 
 By default, focus is returned to the original window after executing the command
 (except for floating terminals). Use argument `go_back=0` to disable this behaviour.

--- a/lua/toggleterm/commandline.lua
+++ b/lua/toggleterm/commandline.lua
@@ -15,6 +15,7 @@ local is_windows = vim.loop.os_uname().version:match("Windows")
 ---@field cmd string?
 ---@field dir string?
 ---@field size number?
+---@field name string?
 ---@field go_back boolean?
 ---@field open boolean?
 
@@ -144,12 +145,16 @@ local term_exec_options = {
   --- The size param takes in arbitrary numbers, we keep this function only to
   --- match the signature of other options
   size = function() return {} end,
+  --- The name param takes in arbitrary strings, we keep this function only to
+  --- match the signature of other options
+  name = function() return {} end,
 }
 
 local toggle_term_options = {
   dir = term_exec_options.dir,
   direction = term_exec_options.direction,
   size = term_exec_options.size,
+  name = term_exec_options.name,
 }
 
 ---@param options table a dictionary of key to function

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -195,6 +195,7 @@ function Terminal:new(term)
   self.__index = self
   term.direction = term.direction or conf.direction
   term.id = id or next_id()
+  term.display_name = term.display_name
   term.float_opts = vim.tbl_deep_extend("keep", term.float_opts or {}, conf.float_opts)
   term.clear_env = term.clear_env
   term.auto_scroll = vim.F.if_nil(term.auto_scroll, conf.auto_scroll)
@@ -518,13 +519,14 @@ end
 ---@param num number?
 ---@param dir string?
 ---@param direction string?
+---@param name string?
 ---@return Terminal
 ---@return boolean
-function M.get_or_create_term(num, dir, direction)
+function M.get_or_create_term(num, dir, direction, name)
   local term = M.get(num)
   if term then return term, false end
   if dir and fn.isdirectory(fn.expand(dir)) == 0 then dir = nil end
-  return Terminal:new({ id = num, dir = dir, direction = direction }), true
+  return Terminal:new({ id = num, dir = dir, direction = direction, display_name = name }), true
 end
 
 ---Get a single terminal by id, unless it is hidden

--- a/tests/command-complete_spec.lua
+++ b/tests/command-complete_spec.lua
@@ -3,7 +3,7 @@ describe("command-complete", function()
   it("should return the default options", function()
     local results = command_complete.term_exec_complete("", "TermExec ", 9)
 
-    assert.is_equal("cmd=, dir=, direction=, size=", table.concat(results, ", "))
+    assert.is_equal("cmd=, dir=, direction=, name=, size=", table.concat(results, ", "))
   end)
 
   describe("helpers", function()

--- a/tests/commandline_spec.lua
+++ b/tests/commandline_spec.lua
@@ -34,6 +34,13 @@ describe("Commandline tests:", function()
     assert.equal(34, result.size)
   end)
 
+  it("should handle name args correctly", function()
+    local result = parser.parse("name=sample")
+    assert.is_truthy(result.name)
+    assert.is_true(type(result.name) == "string")
+    assert.equal("sample", result.name)
+  end)
+
   it("should handle go_back args correctly", function()
     local result = parser.parse("go_back=0")
     assert.is_true(type(result.go_back) == "boolean")


### PR DESCRIPTION
Adding the `name` param to `:ToggleTerm` and `:TermExec` commands to allow setting the `display_name` for the terminal while creating it.

Implements the feature I'd suggested [here](https://github.com/akinsho/toggleterm.nvim/issues/332#issuecomment-1679505869).

Let me know your thoughts. Thanks!