### PR TITLE
fix(#487): avoid terminal id collisions in __add

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -216,6 +216,7 @@ end
 ---@package
 ---Add a terminal to the list of terminals
 function Terminal:__add()
+  if terminals[self.id] and terminals[self.id] ~= self then self.id = next_id() end
   if not terminals[self.id] then terminals[self.id] = self end
   return self
 end


### PR DESCRIPTION
Instead of assigning custom terminals' IDs on spawn, this just ensures that a different terminal does not exist with the same ID. Toggling normal terminals still works, but on spawn / resurrect, if there is a collision the terminal will be given the next available ID. This ensures that no terminals will be overwritten from the list, which previously could happen if a terminal wasn't spawned immediately on creation, or if an "orphaned" terminal was resurrected.