### PR TITLE
Change when to delete a terminal

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -151,7 +151,7 @@ end
 ---Terminal buffer autocommands
 ---@param term Terminal
 local function setup_buffer_autocommands(term)
-  api.nvim_create_autocmd("TermClose", {
+  api.nvim_create_autocmd("BufDelete", {
     buffer = term.bufnr,
     group = AUGROUP,
     callback = function() delete(term.id) end,


### PR DESCRIPTION
Delete the terminal from the list when you delete the buffer, not when the job exits. This allows you to continue toggling and viewing the output even after the job has ended.