### PR TITLE
feat: display name on floating window title

### DIFF
--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -294,6 +294,8 @@ function M._get_float_config(term, opening)
     height = height,
     border = opening and border or nil,
     zindex = opts.zindex or nil,
+    title = opts.title and (term.display_name or ("Terminal "..term.id)),
+    title_pos = opts.title and (opts.title_pos or "center"),
   }
 end
 


### PR DESCRIPTION
This PR adds two new options for floating windows: `title` and `title_pos`. If `title` is true, the floating window will display the terminal's name (or the ID if it has no name).  The position of the title can be controlled via `title_pos` (just like in `nvim_open_win`).