### PR TITLE
clear terminal on windows

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -323,14 +323,21 @@ function Terminal:send(cmd, go_back)
   end
 end
 
-function Terminal:clear() self:send("clear") end
+-- Clear the terminal
+function Terminal:clear() 
+	if vim.fn.has('win32') == 1 then
+		self:send("cls")
+	else
+		self:send("clear")
+	end
+end
 
 ---Update the directory of an already opened terminal
 ---@param dir string
 function Terminal:change_dir(dir, go_back)
   dir = _get_dir(dir)
   if self.dir == dir then return end
-  self:send({ fmt("cd %s", dir), "clear" }, go_back)
+  self:send({ fmt("cd %s", dir), self.clear() }, go_back)
   self.dir = dir
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -323,13 +323,10 @@ function Terminal:send(cmd, go_back)
   end
 end
 
--- Clear the terminal
+--check for os type and perform os specific clear command
 function Terminal:clear() 
-	if vim.fn.has('win32') == 1 then
-		self:send("cls")
-	else
-		self:send("clear")
-	end
+	local clear = is_windows and "cls" or "clear"	
+	self:send(term)
 end
 
 ---Update the directory of an already opened terminal
@@ -337,7 +334,7 @@ end
 function Terminal:change_dir(dir, go_back)
   dir = _get_dir(dir)
   if self.dir == dir then return end
-  self:send({ fmt("cd %s", dir), self.clear() }, go_back)
+  self:send({ fmt("cd %s", dir), self:clear() }, go_back)
   self.dir = dir
 end
 


### PR DESCRIPTION
functionality added to clear an already opened terminal in windows.
clear function is not valid on windows os. Therefore added additional check for os.