### PR TITLE
newline_chr is optionally user-specified

### DIFF
--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -477,13 +477,18 @@ using the current count e.g. `:5ToggleTerm<CR>`
     local lazygit = Terminal:new({ cmd = "lazygit", count = 5 })
 <
 
-You can also set a custom layout for a terminal.
+You can also set several options for the custom terminal including layout,
+opening and closing functions, and the newline charcter used when sending text
+to the terminal. The `newline_chr` defaults to "\r" on powershell, "\r\n" on
+cmd.exe, and "\n" otherwise.
 
 >lua
     local lazygit = Terminal:new({
       cmd = "lazygit",
       dir = "git_dir",
       direction = "float",
+      -- Try changing if you get too many/few blank lines when sending to terminal
+      newline_chr = "\n" 
       float_opts = {
         border = "double",
       },

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -1,4 +1,4 @@
-*toggleterm.txt*       For Neovim >= 0.8.0       Last change: 2023 November 22
+*toggleterm.txt*       For Neovim >= 0.8.0       Last change: 2023 November 27
 
 ==============================================================================
 Table of Contents                               *toggleterm-table-of-contents*

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -478,7 +478,7 @@ using the current count e.g. `:5ToggleTerm<CR>`
 <
 
 You can also set several options for the custom terminal including layout,
-opening and closing functions, and the newline charcter used when sending text
+opening and closing functions, and the newline character used when sending text
 to the terminal. The `newline_chr` defaults to "\r" on powershell, "\r\n" on
 cmd.exe, and "\n" otherwise.
 
@@ -487,7 +487,6 @@ cmd.exe, and "\n" otherwise.
       cmd = "lazygit",
       dir = "git_dir",
       direction = "float",
-      -- Try changing if you get too many/few blank lines when sending to terminal
       newline_chr = "\n" 
       float_opts = {
         border = "double",

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -46,6 +46,7 @@ end
 local terminals = {}
 
 --- @class TermCreateArgs
+--- @field newline_chr? string user specified newline chararacter
 --- @field cmd? string a custom command to run
 --- @field direction? string the layout style for the terminal
 --- @field id number?
@@ -65,6 +66,7 @@ local terminals = {}
 --- @field on_close fun(term:Terminal)?
 
 --- @class Terminal
+--- @field newline_chr string
 --- @field cmd string
 --- @field direction string the layout style for the terminal
 --- @field id number
@@ -193,6 +195,7 @@ function Terminal:new(term)
   if id and terminals[id] then return terminals[id] end
   local conf = config.get()
   self.__index = self
+  term.newline_chr = term.newline_chr or get_newline_chr()
   term.direction = term.direction or conf.direction
   term.id = id or next_id()
   term.display_name = term.display_name
@@ -287,10 +290,11 @@ end
 
 ---Combine arguments into strings separated by new lines
 ---@vararg string
+---@param newline_chr string
 ---@return string
-local function with_cr(...)
+local function with_cr(newline_chr, ...)
   local result = {}
-  local newline_chr = get_newline_chr()
+  -- local newline_chr = get_newline_chr()
   for _, str in ipairs({ ... }) do
     table.insert(result, str .. newline_chr)
   end
@@ -312,7 +316,7 @@ end
 ---@param cmd string|string[]
 ---@param go_back boolean? whether or not to return to original window
 function Terminal:send(cmd, go_back)
-  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(cmd --[[@as string]])
+  cmd = type(cmd) == "table" and with_cr(self.newline_chr, unpack(cmd)) or with_cr(self.newline_chr, cmd --[[@as string]])
   fn.chansend(self.job_id, cmd)
   self:scroll_bottom()
   if go_back and self:is_focused() then

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -294,7 +294,6 @@ end
 ---@return string
 local function with_cr(newline_chr, ...)
   local result = {}
-  -- local newline_chr = get_newline_chr()
   for _, str in ipairs({ ... }) do
     table.insert(result, str .. newline_chr)
   end


### PR DESCRIPTION
R on cmd.exe on windows adds an extra newline using the current logic (newline is chosen as: "\r\n"). This proposal makes `newline_chr` a property of the `Terminal`, and allows the user to specify it's value when creating custom terminals.