### PR TITLE
Fix: wrongly sending prior keypresses when opening float terminal+changingdirectory

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -313,7 +313,7 @@ end
 ---@param go_back boolean? whether or not to return to original window
 function Terminal:send(cmd, go_back)
   cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(cmd --[[@as string]])
-  fn.chansend(self.job_id, cmd)
+  api.nvim_chan_send(self.job_id, cmd)
   self:scroll_bottom()
   if go_back and self:is_focused() then
     ui.goto_previous()


### PR DESCRIPTION
Terminal would fail to switch directory because of sending prior key presses behind the 'cd ~/example', failing to change directory because it would run command '321k33cd ~/example' or fail to enter the command at all.

Changed fn.chansend to vim.api.nvim_chan_send. Fixed issue on my system.

I noticed this when quickswitching to another buffer using Telescope in a toggleterm float when escaped from the terminal

-Persist mode was enabled
-Windows Terminal