### PR TITLE
doc(float_opts): add number/function description of row and col

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ require("toggleterm").setup{
     -- the 'curved' border is a custom border type
     -- not natively supported but implemented in this plugin.
     border = 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
-    -- like `size`, width and height can be a number or function which is passed the current terminal
+    -- like `size`, width, height, row, and col can be a number or function which is passed the current terminal
     width = <value>,
     height = <value>,
+    row = <value>,
+    col = <value>,
     winblend = 3,
     zindex = <value>,
     title_pos = 'left' | 'center' | 'right', position of the title of the floating window

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -190,9 +190,11 @@ what options are available. It is not written to be used as is.
         -- the 'curved' border is a custom border type
         -- not natively supported but implemented in this plugin.
         border = 'single' | 'double' | 'shadow' | 'curved' | ... other options supported by win open
-        -- like `size`, width and height can be a number or function which is passed the current terminal
+        -- like `size`, width, height, row, and col can be a number or function which is passed the current terminal
         width = <value>,
         height = <value>,
+        row = <value>,
+        col = <value>,
         winblend = 3,
         zindex = <value>,
         title_pos = 'left' | 'center' | 'right', position of the title of the floating window


### PR DESCRIPTION
**UPDATE:**

A doc-only change to describe that `row` and `col` are also configurable via number or function, like `width` and `height`.

-----

**Original description:**

~This one-line patch allows me to do something like this:~

```
vim.g.toggle_quake_float = true
```

~in my `init.lua`. Then by setting~

```
float_opts = {
  height = math.floor(vim.o.lines * 0.4),
  width = vim.o.columns,
}
```

~I get a true Quake-style float terminal.~

~It didn't seem worthwhile to create an entirely new `direction` when it's such a tiny variation on the existing `float`, but there might be an argument to make it part of the `float_opts` table?~

~If you think this change is worth incorporating, I can add the corresponding paragraph to `toggleterm.txt`.~

