### PR TITLE
feat: enabling title for floating terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ require("toggleterm").setup{
     height = <value>,
     winblend = 3,
     zindex = <value>,
+    title_pos = 'left' | 'center' | 'right', position of the title of the floating window
   },
   winbar = {
     enabled = false,

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -195,6 +195,7 @@ what options are available. It is not written to be used as is.
         height = <value>,
         winblend = 3,
         zindex = <value>,
+        title_pos = 'left' | 'center' | 'right', position of the title of the floating window
       },
       winbar = {
         enabled = false,

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -34,6 +34,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 --- @field highlights ToggleTermHighlights
 --- @field winbar WinbarOpts
 --- @field autochdir boolean
+--- @field title_pos '"left"' | '"center"' | '"right"'
 
 ---@type ToggleTermConfig
 local config = {
@@ -58,6 +59,7 @@ local config = {
   },
   float_opts = {
     winblend = 0,
+    title_pos = 'left'
   },
 }
 

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -285,7 +285,9 @@ function M._get_float_config(term, opening)
   row = vim.F.if_nil(M._resolve_size(opts.row, term), row)
   col = vim.F.if_nil(M._resolve_size(opts.col, term), col)
 
-  return {
+  local version = vim.version()
+
+  local float_config = {
     row = row,
     col = col,
     relative = opts.relative or "editor",
@@ -295,6 +297,11 @@ function M._get_float_config(term, opening)
     border = opening and border or nil,
     zindex = opts.zindex or nil,
   }
+  if version.major > 0 or version.minor >= 9 then
+    float_config.title_pos = term.display_name and opts.title_pos or nil
+    float_config.title = term.display_name
+  end
+  return float_config
 end
 
 --- @param size number


### PR DESCRIPTION
Got an idea from #504 PR

- title is enabled when `display_name` is provided
- will not fail on NeoVim versions prior to 0.9
- added documentation entries
- `title_pos` is under more appropriate  `float_opts` section