### PR TITLE
fix: add rate limit for repeated ToggleTerm trigger

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -253,7 +253,16 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, cmd_data)
   api.nvim_win_set_cursor(current_window, { start_line, start_col })
 end
 
+local last_toggle_sec = 0
+local last_toggle_nano_sec = 0
 function M.toggle_command(args, count)
+  local sec, nano_sec = vim.loop.gettimeofday()
+  local diff = (sec - last_toggle_sec) * 1000000 + nano_sec - last_toggle_nano_sec
+  -- less then 150ms
+  if diff < 150 * 1000 then
+    return
+  end
+
   local parsed = commandline.parse(args)
   vim.validate({
     size = { parsed.size, "number", true },
@@ -263,6 +272,7 @@ function M.toggle_command(args, count)
   })
   if parsed.size then parsed.size = tonumber(parsed.size) end
   M.toggle(count, parsed.size, parsed.dir, parsed.direction, parsed.name)
+  last_toggle_sec, last_toggle_nano_sec = vim.loop.gettimeofday()
 end
 
 function _G.___toggleterm_winbar_click(id)


### PR DESCRIPTION
Issue: when terminal_mapping is enabled and key-mapping is 'Ctrl + \', if I hold 'Ctrl + \' for long time, ToggleTerm command will be triggerd repeatly(show and hide for floating terminal). If the combo-key(Ctrl + \) is released slightly slower(depend on keyboard), ToggleTerm will be triggered twice, causing the floating terminal window to briefly appear and then immediately hide again.

To address the above issue, I have implemented a delay mechanism that checks the time difference between the current ToggleTerm and the previous one. If the difference is less than 150ms, it will be ignored.

This modification is quite dirty, and I hope it can serve as a starting point for further improvements.