### PR TITLE
Bugfix: toggleterm.send_lines_to_terminal wasn't passing id to M.exec() when trim_spaces = false

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -240,7 +240,7 @@ function M.send_lines_to_terminal(selection_type, trim_spaces, cmd_data)
   if not lines or not next(lines) then return end
 
   if not trim_spaces then
-    M.exec(table.concat(lines, "\n"))
+    M.exec(table.concat(lines, "\n"), id)
   else
     for _, line in ipairs(lines) do
       local l = trim_spaces and line:gsub("^%s+", ""):gsub("%s+$", "") or line


### PR DESCRIPTION
This pull request simply adds `id` to the arguments passed to `M.exec()` when `trim_spaces = false` in `toggleterm.send_lines_to_terminal`.

This wasn't causing issues for the various user commands (e.g., `ToggleTermSendCurrentLine`) because they all set `trim_spaces = true`. 

It was causing issues for implementations that call `send_lines_to_terminal` with `trim_spaces = true` that tried sending text to terminals other than the first terminal, where `term.id != 1`; Text was always sent to the first terminal.