### PR TITLE
fix: autochdir for custom terminals

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -489,9 +489,7 @@ function Terminal:open(size, direction)
     local ok, err = pcall(opener, size, self)
     if not ok and err then return utils.notify(err, "error") end
     ui.switch_buf(self.bufnr)
-    if config.autochdir then
-      if self.dir ~= cwd then self:change_dir(cwd) end
-    end
+    if config.autochdir and self.dir ~= cwd then self:change_dir(cwd) end
   end
   ui.hl_term(self)
   -- NOTE: it is important that this function is called at this point. i.e. the buffer has been correctly assigned

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -477,7 +477,8 @@ end
 ---@param size number?
 ---@param direction string?
 function Terminal:open(size, direction)
-  self.dir = _get_dir(self.dir)
+  local cwd = fn.getcwd()
+  self.dir = _get_dir(config.autochdir and cwd or self.dir)
   ui.set_origin_window()
   if direction then self:change_direction(direction) end
   if not self.bufnr or not api.nvim_buf_is_valid(self.bufnr) then
@@ -489,7 +490,6 @@ function Terminal:open(size, direction)
     if not ok and err then return utils.notify(err, "error") end
     ui.switch_buf(self.bufnr)
     if config.autochdir then
-      local cwd = fn.getcwd()
       if self.dir ~= cwd then self:change_dir(cwd) end
     end
   end


### PR DESCRIPTION
Currently, autochdir won't work for custom terminals.

So currently I encounter scenarios like the following: Opening a custom terminal with i.e lazygit in a git project then closing the terminal, switching buffers to another git project and re toggling it, keeps opening lazygit in the first directory.

The changes in the PR aim to make this functionality work - switching buffers in the same session to another git project and opening a custom terminal should open it with the new git projects working directory.