### PR TITLE
feat: add the command ToggleTermBufferDir to create and/or toggle a terminal with the current buffer directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ when using `TermSelect` command to indicate the specific terminal.
 `size` and `direction` are ignored if the command closes a terminal.
 
 
-### `TOGGLETERMTOBUFFERDIR`
+### `TOGGLETERMBUFFERDIR`
 
 This command switches the buffer directory in the terminal.
 If a terminal instance with a buffer directory wasn't already there,
@@ -266,7 +266,7 @@ Default `name=PATH_TO_CURRENT_BUFFER` and `direction=float`,size if taken from
 setup function.
 
 ```vim
-:ToggleTermToBufferDir name=desctop direction=horizontal
+:ToggleTermBufferDir name=desctop direction=horizontal
 ```
 If `direction` is specified, and the command opens a terminal, the terminal
 will be changed to the specified direction.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ when using `TermSelect` command to indicate the specific terminal.
 `size` and `direction` are ignored if the command closes a terminal.
 
 
-### `TOGGLETERMBUFFERDIR`
+### `ToggleTermBufferDir`
 
 This command switches the buffer directory in the terminal.
 If a terminal instance with a buffer directory wasn't already there,

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ when using `TermSelect` command to indicate the specific terminal.
 
 ### `ToggleTermBufferDir`
 
-https://github.com/TimaSv-Uk/toggleterm.nvim/assets/116874286/85269561-8d7c-4e8d-8571-c43ac625dd59
+https://github.com/TimaSv-Uk/toggleterm.nvim/assets/116874286/c672605f-f4ba-4d66-a1fe-67568d4d42f5
 
 This command switches the buffer directory in the terminal.
 If a terminal instance with a buffer directory wasn't already there,

--- a/README.md
+++ b/README.md
@@ -252,6 +252,29 @@ when using `TermSelect` command to indicate the specific terminal.
 
 `size` and `direction` are ignored if the command closes a terminal.
 
+
+### `TOGGLETERMTOBUFFERDIR`
+
+This command switches the buffer directory in the terminal.
+If a terminal instance with a buffer directory wasn't already there,
+one is created.You are unable to change the buffer terminal name or
+direction after creating a terminal instance.
+
+You can use `:TermSelect` to utilize toggleterm from another buffer in the current buffer.
+
+Default `name=PATH_TO_CURRENT_BUFFER` and `direction=float`,size if taken from
+setup function.
+
+```vim
+:ToggleTermToBufferDir name=desctop direction=horizontal
+```
+If `direction` is specified, and the command opens a terminal, the terminal
+will be changed to the specified direction.
+
+If `name` is specified, the display name is set for the toggled terminal. This
+name will be visible when using `TermSelect` command to indicate the specific
+terminal.
+
 #### Caveats
 
 - Having multiple terminals with different directions open at the same time is unsupported.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ when using `TermSelect` command to indicate the specific terminal.
 
 ### `ToggleTermBufferDir`
 
+https://github.com/TimaSv-Uk/toggleterm.nvim/assets/116874286/85269561-8d7c-4e8d-8571-c43ac625dd59
+
 This command switches the buffer directory in the terminal.
 If a terminal instance with a buffer directory wasn't already there,
 one is created.You are unable to change the buffer terminal name or

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,9 @@
+almost	toggleterm.txt	/*almost*
+toggleterm-installation	toggleterm.txt	/*toggleterm-installation*
+toggleterm-links	toggleterm.txt	/*toggleterm-links*
+toggleterm-notices	toggleterm.txt	/*toggleterm-notices*
+toggleterm-requirements	toggleterm.txt	/*toggleterm-requirements*
+toggleterm-roadmap	toggleterm.txt	/*toggleterm-roadmap*
+toggleterm-table-of-contents	toggleterm.txt	/*toggleterm-table-of-contents*
+toggleterm-why?	toggleterm.txt	/*toggleterm-why?*
+toggleterm.txt	toggleterm.txt	/*toggleterm.txt*

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -244,7 +244,7 @@ terminal.
 `size` and `direction` are ignored if the command closes a terminal.
 
 
-TOGGLETERMTOBUFFERDIR
+TOGGLETERMBUFFERDIR
 
 This command switches the buffer directory displayed in the terminal.
 If a terminal instance with a buffer directory wasn't already there,
@@ -256,7 +256,7 @@ You can use :TermSelect to utilize toggleterm from another buffer in the current
 Default `name=PATH_TO_CURRENT_BUFFER` and `direction=float`,size if taken from
 setup function.
 
-    :ToggleTermToBufferDir name=desctop direction=horizontal
+    :ToggleTermBufferDir name=desctop direction=horizontal
 
 If `direction` is specified, and the command opens a terminal, the terminal
 will be changed to the specified direction.

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -244,6 +244,27 @@ terminal.
 `size` and `direction` are ignored if the command closes a terminal.
 
 
+TOGGLETERMTOBUFFERDIR
+
+This command switches the buffer directory displayed in the terminal.
+If a terminal instance with a buffer directory wasn't already there,
+one is created.You are unable to change the buffer terminal name or
+direction after creating a terminal instance.
+
+You can use :TermSelect to utilize toggleterm from another buffer in the current buffer.
+
+Default `name=PATH_TO_CURRENT_BUFFER` and `direction=float`,size if taken from
+setup function.
+
+    :ToggleTermToBufferDir name=desctop direction=horizontal
+
+If `direction` is specified, and the command opens a terminal, the terminal
+will be changed to the specified direction.
+
+If `name` is specified, the display name is set for the toggled terminal. This
+name will be visible when using `TermSelect` command to indicate the specific
+terminal.
+
 CAVEATS
 
 - Having multiple terminals with different directions open at the same time is unsupported.

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -489,7 +489,7 @@ local function setup_commands()
   end, { nargs = "?", count = true })
 
   command(
-    "ToggleTermToBufferDir",
+    "ToggleTermBufferDir",
     function(opts)
       local function splitKeyValuePairs(inputstr)
         local result = {}


### PR DESCRIPTION
This PR introduces the :ToggleTermBufferDir command, which allows users to switch the buffer directory in the terminal. If a terminal instance with a buffer directory wasn’t already there, one is created. However, once a terminal instance is created, the buffer terminal name or direction cannot be changed.

The :TermSelect command can be used to utilize toggleterm from another buffer in the current buffer. By default, the **name** is set to PATH_TO_CURRENT_BUFFER and the **direction** is set to float. The size is taken from the setup function.

Here is an example usage of the command:
`
:ToggleTermBufferDir name=desktop direction=horizontal`

I love to use Harpoon or Telescop, and the new command allows me to quickly open Terminla after jumping to a new project. If there are any issues, I'll try to fix them.

Uploading ToggleTermBufferDir_example.mp4…

