### PR TITLE
Add string array support to `open_mapping` setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ I'm also going to be pretty conservative about what I add.
 
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
-Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode.
+Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode. The `open_mappint` can be a key string or an array of key strings. 
 If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened. In case there are multiple terminals opened they'll all be closed, and on the next mapping key they'll be restored.
 
 If you set the `insert_mappings` key to `true`, the mapping will also take effect in insert mode; similarly setting `terminal_mappings` to `true` will have the mappings take effect in the opened terminal.
@@ -161,7 +161,7 @@ require("toggleterm").setup{
       return vim.o.columns * 0.4
     end
   end,
-  open_mapping = [[<c-\>]],
+  open_mapping = [[<c-\>]], -- or { [[<c-\>]], [[<c-¥>]] } if you also use a Japanese keyboard.
   on_create = fun(t: Terminal), -- function to run when the terminal is first created
   on_open = fun(t: Terminal), -- function to run when the terminal opens
   on_close = fun(t: Terminal), -- function to run when the terminal closes

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ I'm also going to be pretty conservative about what I add.
 
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
-Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode. The `open_mappint` can be a key string or an array of key strings. 
+Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode. The `open_mapping` can be a key string or an array of key strings. 
 If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened. In case there are multiple terminals opened they'll all be closed, and on the next mapping key they'll be restored.
 
 If you set the `insert_mappings` key to `true`, the mapping will also take effect in insert mode; similarly setting `terminal_mappings` to `true` will have the mappings take effect in the opened terminal.

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -102,7 +102,7 @@ SETUP ~
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
 Setting the `open_mapping` key to use for toggling the terminal(s) will set up
-mappings for _normal_ mode. The `open_mappint` can be a key string or an array
+mappings for _normal_ mode. The `open_mapping` can be a key string or an array
 of key strings.  If you prefix the mapping with a number that particular
 terminal will be opened. Otherwise if a prefix is not set, then the last
 toggled terminal will be opened. In case there are multiple terminals opened

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -102,11 +102,11 @@ SETUP ~
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
 Setting the `open_mapping` key to use for toggling the terminal(s) will set up
-mappings for _normal_ mode. If you prefix the mapping with a number that
-particular terminal will be opened. Otherwise if a prefix is not set, then the
-last toggled terminal will be opened. In case there are multiple terminals
-opened they’ll all be closed, and on the next mapping key they’ll be
-restored.
+mappings for _normal_ mode. The `open_mappint` can be a key string or an array
+of key strings.  If you prefix the mapping with a number that particular
+terminal will be opened. Otherwise if a prefix is not set, then the last
+toggled terminal will be opened. In case there are multiple terminals opened
+they’ll all be closed, and on the next mapping key they’ll be restored.
 
 If you set the `insert_mappings` key to `true`, the mapping will also take
 effect in insert mode; similarly setting `terminal_mappings` to `true` will
@@ -147,7 +147,7 @@ what options are available. It is not written to be used as is.
           return vim.o.columns * 0.4
         end
       end,
-      open_mapping = [[<c-\>]],
+      open_mapping = [[<c-\>]], -- or { [[<c-\>]], [[<c-¥>]] } if you also use a Japanese keyboard.
       on_create = fun(t: Terminal), -- function to run when the terminal is first created
       on_open = fun(t: Terminal), -- function to run when the terminal opens
       on_close = fun(t: Terminal), -- function to run when the terminal closes

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -38,7 +38,7 @@ local function setup_global_mappings()
 
   -- Key mapping function
   ---@param key string
-  local map = function(key)
+  local function map(key)
     -- v:count defaults the count to 0 but if a count is passed in uses that instead
     vim.keymap.set("n", key, '<Cmd>execute v:count . "ToggleTerm"<CR>', {
       desc = "Toggle Terminal",
@@ -52,8 +52,9 @@ local function setup_global_mappings()
     end
   end
 
-  if type(mapping) == "string" then map(mapping) end
-  if type(mapping) == "table" then
+  if type(mapping) == "string" then
+    map(mapping)
+  elseif type(mapping) == "table" then
     for _, key in pairs(mapping) do
       map(key)
     end

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -35,28 +35,17 @@ end
 
 local function setup_global_mappings()
   local mapping = config.open_mapping
-
-  -- Key mapping function
-  ---@param key string
-  local function map(key)
-    -- v:count defaults the count to 0 but if a count is passed in uses that instead
-    vim.keymap.set("n", key, '<Cmd>execute v:count . "ToggleTerm"<CR>', {
+  -- v:count defaults the count to 0 but if a count is passed in uses that instead
+  if mapping then
+    utils.key_map("n", mapping, '<Cmd>execute v:count . "ToggleTerm"<CR>', {
       desc = "Toggle Terminal",
       silent = true,
     })
     if config.insert_mappings then
-      vim.keymap.set("i", key, "<Esc><Cmd>ToggleTerm<CR>", {
+      utils.key_map("i", mapping, "<Esc><Cmd>ToggleTerm<CR>", {
         desc = "Toggle Terminal",
         silent = true,
       })
-    end
-  end
-
-  if type(mapping) == "string" then
-    map(mapping)
-  elseif type(mapping) == "table" then
-    for _, key in pairs(mapping) do
-      map(key)
     end
   end
 end

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -35,17 +35,27 @@ end
 
 local function setup_global_mappings()
   local mapping = config.open_mapping
-  -- v:count defaults the count to 0 but if a count is passed in uses that instead
-  if mapping then
-    vim.keymap.set("n", mapping, '<Cmd>execute v:count . "ToggleTerm"<CR>', {
+
+  -- Key mapping function
+  ---@param key string
+  local map = function(key)
+    -- v:count defaults the count to 0 but if a count is passed in uses that instead
+    vim.keymap.set("n", key, '<Cmd>execute v:count . "ToggleTerm"<CR>', {
       desc = "Toggle Terminal",
       silent = true,
     })
     if config.insert_mappings then
-      vim.keymap.set("i", mapping, "<Esc><Cmd>ToggleTerm<CR>", {
+      vim.keymap.set("i", key, "<Esc><Cmd>ToggleTerm<CR>", {
         desc = "Toggle Terminal",
         silent = true,
       })
+    end
+  end
+
+  if type(mapping) == "string" then map(mapping) end
+  if type(mapping) == "table" then
+    for _, key in pairs(mapping) do
+      map(key)
     end
   end
 end

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -18,7 +18,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 --- @field size number
 --- @field shade_filetypes string[]
 --- @field hide_numbers boolean
---- @field open_mapping string
+--- @field open_mapping string | string[]
 --- @field shade_terminals boolean
 --- @field insert_mappings boolean
 --- @field terminal_mappings boolean

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -132,21 +132,8 @@ end
 --- @param bufnr number
 local function setup_buffer_mappings(bufnr)
   local mapping = config.open_mapping
-
-  -- Key mapping function
-  ---@param key string
-  local map = function(key)
-    vim.keymap.set("t", key, "<Cmd>ToggleTerm<CR>", { buffer = bufnr, silent = true })
-  end
-
-  if config.terminal_mappings then
-    if type(mapping) == "string" then
-      map(mapping)
-    elseif type(mapping) == "table" then
-      for _, key in pairs(mapping) do
-        map(key)
-      end
-    end
+  if mapping and config.terminal_mappings then
+    utils.key_map("t", mapping, "<Cmd>ToggleTerm<CR>", { buffer = bufnr, silent = true })
   end
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -140,8 +140,9 @@ local function setup_buffer_mappings(bufnr)
   end
 
   if config.terminal_mappings then
-    if type(mapping) == "string" then map(mapping) end
-    if type(mapping) == "table" then
+    if type(mapping) == "string" then
+      map(mapping)
+    elseif type(mapping) == "table" then
       for _, key in pairs(mapping) do
         map(key)
       end

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -132,8 +132,20 @@ end
 --- @param bufnr number
 local function setup_buffer_mappings(bufnr)
   local mapping = config.open_mapping
-  if mapping and config.terminal_mappings then
-    vim.keymap.set("t", mapping, "<Cmd>ToggleTerm<CR>", { buffer = bufnr, silent = true })
+
+  -- Key mapping function
+  ---@param key string
+  local map = function(key)
+    vim.keymap.set("t", key, "<Cmd>ToggleTerm<CR>", { buffer = bufnr, silent = true })
+  end
+
+  if config.terminal_mappings then
+    if type(mapping) == "string" then map(mapping) end
+    if type(mapping) == "table" then
+      for _, key in pairs(mapping) do
+        map(key)
+      end
+    end
   end
 end
 

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -48,6 +48,21 @@ end
 ---@param sep string
 function M.concat_without_empty(tbl, sep) return table.concat(M.tbl_filter_empty(tbl), sep) end
 
+-- Key mapping function
+---@param mod string | string[]
+---@param lhs string | string[]
+---@param rhs string | function
+---@param opts table?
+function M.key_map(mod, lhs, rhs, opts)
+  if type(lhs) == "string" then
+    vim.keymap.set(mod, lhs, rhs, opts)
+  elseif type(lhs) == "table" then
+    for _, key in pairs(lhs) do
+      vim.keymap.set(mod, key, rhs, opts)
+    end
+  end
+end
+
 ---@param mode "visual" | "motion"
 ---@return table
 function M.get_line_selection(mode)


### PR DESCRIPTION
I sometime use a Japanese keyboard, and it don't have the `\` key, instead it have a `¥` key.

It would be helpful for people like me who what to bind multiple keys for toggle terminal. So I modified the `open_mapping` setting to also take an array of string as parameter.