### PR TITLE
fix: ensure `on_choice` operates on exact `items` element

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -394,7 +394,8 @@ local function select_terminal(opts)
   vim.ui.select(terminals, {
     prompt = "Please select a terminal to open (or focus): ",
     format_item = function(term) return term.id .. ": " .. term:_display_name() end,
-  }, function(term)
+  }, function(_, idx)
+    local term = terminals[idx]
     if not term then return end
     if term:is_open() then
       term:focus()


### PR DESCRIPTION
As `on_choice()` actions depend on modifying terminal objects in place, make sure to operate on exact element and not a copy. As users can override `vim.ui.select()`, its implementation might return an item's copy (which is not explicitly prohibited) making later `on_choice()` actions not 100% full proof.