### PR TITLE
Add shading_ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ require("toggleterm").setup{
     },
   },
   shade_terminals = true, -- NOTE: this option takes priority over highlights specified so if you specify Normal highlights you should set this to false
-  shading_factor = '<number>', -- the percentage by which to lighten terminal background, default: -30 (gets multiplied by -3 if background is light)
+  shading_factor = '<number>', -- the percentage by which to lighten dark terminal background, default: -30
+  shading_ratio = '<number>', -- the ratio of shading factor for light/dark terminal background, default: -3
   start_in_insert = true,
   insert_mappings = true, -- whether or not the open mapping applies in insert mode
   terminal_mappings = true, -- whether or not the open mapping applies in the opened terminals

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -28,6 +28,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 --- @field close_on_exit boolean
 --- @field direction  '"horizontal"' | '"vertical"' | '"float"'
 --- @field shading_factor number
+--- @field shading_ratio number
 --- @field shell string|fun():string
 --- @field auto_scroll boolean
 --- @field float_opts table<string, any>
@@ -50,6 +51,7 @@ local config = {
   close_on_exit = true,
   direction = "horizontal",
   shading_factor = constants.shading_amount,
+  shading_ratio = constants.shading_ratio,
   shell = vim.o.shell,
   autochdir = false,
   auto_scroll = true,
@@ -91,7 +93,7 @@ local function get_highlights(conf)
 
   if conf.shade_terminals then
     local is_bright = colors.is_bright_background()
-    local degree = is_bright and -3 or 1
+    local degree = is_bright and conf.shading_ratio or 1
     local amount = conf.shading_factor * degree
     local normal_bg = colors.get_hex("Normal", "bg")
     local terminal_bg = conf.shade_terminals and shade(normal_bg, amount) or normal_bg

--- a/lua/toggleterm/constants.lua
+++ b/lua/toggleterm/constants.lua
@@ -3,8 +3,9 @@ local M = {}
 -- Constants
 -----------------------------------------------------------
 M.FILETYPE = "toggleterm"
--- -30 is a magic number based on manual testing of what looks good
+-- -30 and -3 is a magic number based on manual testing of what looks good
 M.shading_amount = -30
+M.shading_ratio = -3
 -- Highlight group name prefix
 M.highlight_group_name_prefix = "ToggleTerm"
 


### PR DESCRIPTION
Fixes #579. 

Added a `shading_ratio` option that defaults to `-3`.
The bright background shading factor becomes `config.shading_ratio * config.shading_factor` after this change.
No breaking change is introduced by this pr.