### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ local lazygit = Terminal:new({
   end,
   -- function to run on closing the terminal
   on_close = function(term)
-    vim.cmd("startinsert!")
+    vim.cmd("bufdo e")
   end,
 })
 


### PR DESCRIPTION
When changing branches via toggleterm & lazygit, your buffers don't automatically update with the new branch contents. 

Currently, you have to run a manual `:e!` command or restart neovim to see the changes. Running `:bufdo e` refreshes all of your buffers. You can see the results of the change below. Thanks!

https://github.com/akinsho/toggleterm.nvim/assets/19471665/a47b1b7d-422e-4327-9666-f0f1c342571e

