### PR TITLE
docs: fix lazygit toggle keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ I'm also going to be pretty conservative about what I add.
 
 This plugin must be explicitly enabled by using `require("toggleterm").setup{}`
 
-Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode. The `open_mapping` can be a key string or an array of key strings. 
+Setting the `open_mapping` key to use for toggling the terminal(s) will set up mappings for _normal_ mode. The `open_mapping` can be a key string or an array of key strings.
 If you prefix the mapping with a number that particular terminal will be opened. Otherwise if a prefix is not set, then the last toggled terminal will be opened. In case there are multiple terminals opened they'll all be closed, and on the next mapping key they'll be restored.
 
 If you set the `insert_mappings` key to `true`, the mapping will also take effect in insert mode; similarly setting `terminal_mappings` to `true` will have the mappings take effect in the opened terminal.
@@ -459,7 +459,7 @@ function _lazygit_toggle()
   lazygit:toggle()
 end
 
-vim.api.nvim_set_keymap("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
+vim.api.nvim_set_keymap({ "n", "t" }, "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
 ```
 
 This will create a new terminal, but the specified command is not being run immediately.
@@ -502,7 +502,7 @@ function _lazygit_toggle()
   lazygit:toggle()
 end
 
-vim.api.nvim_set_keymap("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
+vim.api.nvim_set_keymap({ "n", "t" }, "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
 ```
 
 **WARNING**: do not use any of the private functionality of the terminal or other non-public parts of the API as these

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -55,7 +55,7 @@ Using vim-plug <https://github.com/junegunn/vim-plug> in vimscript
 
 >vim
     Plug 'akinsho/toggleterm.nvim', {'tag' : '*'}
-    
+
     lua require("toggleterm").setup()
 <
 
@@ -124,7 +124,7 @@ alternatively you can do this manually (not recommended but, your prerogative)
     " set
     autocmd TermEnter term://*toggleterm#*
           \ tnoremap <silent><c-t> <Cmd>exe v:count1 . "ToggleTerm"<CR>
-    
+
     " By applying the mappings this way you can pass a count to your
     " mapping to open a specific window.
     " For example: 2<C-t> will open terminal 2
@@ -315,7 +315,7 @@ Alternatively, for more fine-grained control and use in mappings, in lua:
         -- Replace with these for the other two options
         -- require("toggleterm").send_lines_to_terminal("visual_lines", trim_spaces, { args = vim.v.count })
         -- require("toggleterm").send_lines_to_terminal("visual_selection", trim_spaces, { args = vim.v.count })
-    
+
     -- For use as an operator map:
     -- Send motion to terminal
     vim.keymap.set("n", [[<leader><c-\>]], function()
@@ -414,7 +414,7 @@ easier once toggled, whilst still keeping it open.
       vim.keymap.set('t', '<C-l>', [[<Cmd>wincmd l<CR>]], opts)
       vim.keymap.set('t', '<C-w>', [[<C-\><C-n><C-w>]], opts)
     end
-    
+
     -- if you only want these mappings for toggle term use term://*toggleterm#* instead
     vim.cmd('autocmd! TermOpen term://* lua set_terminal_keymaps()')
 <
@@ -458,12 +458,12 @@ CUSTOM TERMINAL USAGE
 >lua
     local Terminal  = require('toggleterm.terminal').Terminal
     local lazygit = Terminal:new({ cmd = "lazygit", hidden = true })
-    
+
     function _lazygit_toggle()
       lazygit:toggle()
     end
-    
-    vim.api.nvim_set_keymap("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
+
+    vim.api.nvim_set_keymap({ "n", "t" }, "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
 <
 
 This will create a new terminal, but the specified command is not being run
@@ -503,12 +503,12 @@ You can also set a custom layout for a terminal.
         vim.cmd("startinsert!")
       end,
     })
-    
+
     function _lazygit_toggle()
       lazygit:toggle()
     end
-    
-    vim.api.nvim_set_keymap("n", "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
+
+    vim.api.nvim_set_keymap({ "n", "t" }, "<leader>g", "<cmd>lua _lazygit_toggle()<CR>", {noremap = true, silent = true})
 <
 
 **WARNING**do not use any of the private functionality of the terminal or other
@@ -541,10 +541,10 @@ OPEN MULTIPLE TERMINALS SIDE-BY-SIDE ~
 
   Direction    Supported
   ------------ -----------
-  vertical     
-  horizontal   
-  tab          
-  float        
+  vertical
+  horizontal
+  tab
+  float
 Inyour first terminal, you need to leave the `TERMINAL` mode using C-\C-N which
 can be remapped to Esc for ease of use.
 


### PR DESCRIPTION
Add terminal mode to the lazygit example keymap so that you could toggle lazygit and hide it when it's open.