### PR TITLE
fix: set_mode may not be taken into account

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -261,11 +261,11 @@ function Terminal:__restore_mode() self:set_mode(self.__state.mode) end
 ---@param m Mode
 function Terminal:set_mode(m)
   if m == mode.INSERT then
-    vim.cmd("startinsert")
+    vim.schedule(function() vim.cmd("startinsert") end)
   elseif m == mode.NORMAL then
-    vim.cmd("stopinsert")
+    vim.schedule(function() vim.cmd("stopinsert") end)
   elseif m == mode.UNSUPPORTED and config.get("start_in_insert") then
-    vim.cmd("startinsert")
+    vim.schedule(function() vim.cmd("startinsert") end)
   end
 end
 


### PR DESCRIPTION
I'm using quick-access shortcuts to switch to a given terminal:

```
			{ "<M-&>", "<cmd>1 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 1" },
			{ "<M-é>", "<cmd>2 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 2" },
			{ '<M-">', "<cmd>3 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 3" },
			{ "<M-'>", "<cmd>4 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 4" },
			{ "<M-(>", "<cmd>5 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 5" },
			{ "<M-->", "<cmd>6 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 6" },
			{ "<M-è>", "<cmd>7 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 7" },
			{ "<M-_>", "<cmd>8 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 8" },
			{ "<M-ç>", "<cmd>9 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 9" },
			{ "<M-à>", "<cmd>10 ToggleTerm<cr>", mode = { "n", "t" }, desc = "Toggle terminal 10" },
```

With this setup, every time I switch from one terminal to another, the terminal is placed in normal mode.

This PR postpones the `set_mode` command so the mode gets what is expected.