### PR TITLE
Add Responsive Capabilities for horizontal direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ require("toggleterm").setup{
       return term.name
     end
   },
-  responsiveness_settings = {
+  responsiveness = {
     -- breakpoint in terms of `vim.o.columns` at which terminals will start to stack on top of each other
     -- instead of next to each other
+    -- default = 0 which means the feature is turned off
     horizontal_breakpoint = 135,
   }
 }

--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ require("toggleterm").setup{
       return term.name
     end
   },
+  responsiveness_settings = {
+    -- breakpoint in terms of `vim.o.columns` at which terminals will start to stack on top of each other
+    -- instead of next to each other
+    horizontal_breakpoint = 135,
+  }
 }
 ```
 

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -14,6 +14,9 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 ---@field name_formatter fun(term: Terminal):string
 ---@field enabled boolean
 
+--- @class ResponsivenessSettings
+--- @field horizontal_breakpoint number
+
 --- @class ToggleTermConfig
 --- @field size number
 --- @field shade_filetypes string[]
@@ -37,6 +40,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 --- @field winbar WinbarOpts
 --- @field autochdir boolean
 --- @field title_pos '"left"' | '"center"' | '"right"'
+--- @field responsiveness_settings ResponsivenessSettings
 
 ---@type ToggleTermConfig
 local config = {
@@ -65,6 +69,9 @@ local config = {
     winblend = 0,
     title_pos = "left",
   },
+  responsiveness_settings = {
+    horizontal_breakpoint = 135,
+  }
 }
 
 ---Derive the highlights for a toggleterm and merge these with the user's preferences

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -14,7 +14,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 ---@field name_formatter fun(term: Terminal):string
 ---@field enabled boolean
 
---- @class ResponsivenessSettings
+--- @class Responsiveness
 --- @field horizontal_breakpoint number
 
 --- @class ToggleTermConfig
@@ -40,7 +40,7 @@ local function shade(color, factor) return colors.shade_color(color, factor) end
 --- @field winbar WinbarOpts
 --- @field autochdir boolean
 --- @field title_pos '"left"' | '"center"' | '"right"'
---- @field responsiveness_settings ResponsivenessSettings
+--- @field responsiveness Responsiveness
 
 ---@type ToggleTermConfig
 local config = {
@@ -69,8 +69,8 @@ local config = {
     winblend = 0,
     title_pos = "left",
   },
-  responsiveness_settings = {
-    horizontal_breakpoint = 135,
+  responsiveness = {
+    horizontal_breakpoint = 0,
   },
 }
 

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -71,7 +71,7 @@ local config = {
   },
   responsiveness_settings = {
     horizontal_breakpoint = 135,
-  }
+  },
 }
 
 ---Derive the highlights for a toggleterm and merge these with the user's preferences

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -318,7 +318,7 @@ function M.open_split(size, term)
     if config.persist_size then M.save_window_size(term.direction, split_win.window) end
     api.nvim_set_current_win(split_win.window)
     local window_width = vim.o.columns
-    local horizontal_breakpoint = config.get("responsiveness").horizontal_breakpoint
+    local horizontal_breakpoint = config.responsiveness.horizontal_breakpoint
     if term.direction == "horizontal" and window_width < horizontal_breakpoint then
       vim.cmd(commands.existing_stacked)
     else

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -224,6 +224,7 @@ end
 local split_commands = {
   horizontal = {
     existing = "rightbelow vsplit",
+    existing_stacked = "rightbelow split",
     new = "botright split",
     resize = "resize",
   },
@@ -316,7 +317,13 @@ function M.open_split(size, term)
     local split_win = windows[#windows]
     if config.persist_size then M.save_window_size(term.direction, split_win.window) end
     api.nvim_set_current_win(split_win.window)
-    vim.cmd(commands.existing)
+    local window_width = vim.o.columns
+    local horizontal_breakpoint = require("toggleterm.config").get("responsiveness_settings").horizontal_breakpoint
+    if term.direction == "horizontal" and window_width < horizontal_breakpoint then
+      vim.cmd(commands.existing_stacked)
+    else
+      vim.cmd(commands.existing)
+    end
   else
     vim.cmd(commands.new)
   end

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -318,8 +318,7 @@ function M.open_split(size, term)
     if config.persist_size then M.save_window_size(term.direction, split_win.window) end
     api.nvim_set_current_win(split_win.window)
     local window_width = vim.o.columns
-    local horizontal_breakpoint =
-      require("toggleterm.config").get("responsiveness_settings").horizontal_breakpoint
+    local horizontal_breakpoint = config.get("responsiveness").horizontal_breakpoint
     if term.direction == "horizontal" and window_width < horizontal_breakpoint then
       vim.cmd(commands.existing_stacked)
     else

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -318,7 +318,8 @@ function M.open_split(size, term)
     if config.persist_size then M.save_window_size(term.direction, split_win.window) end
     api.nvim_set_current_win(split_win.window)
     local window_width = vim.o.columns
-    local horizontal_breakpoint = require("toggleterm.config").get("responsiveness_settings").horizontal_breakpoint
+    local horizontal_breakpoint =
+      require("toggleterm.config").get("responsiveness_settings").horizontal_breakpoint
     if term.direction == "horizontal" and window_width < horizontal_breakpoint then
       vim.cmd(commands.existing_stacked)
     else

--- a/stylua.toml
+++ b/stylua.toml
@@ -2,4 +2,4 @@ column_width = 100
 indent_type = "Spaces"
 quote_style = "AutoPreferDouble"
 indent_width = 2
-collapse_simple_statement = 'Always'
+collapse_simple_statement = "Always"


### PR DESCRIPTION
# Context
When using Neovim with toggleterm in a vertical monitor there is not enough space to see the output of 2 or more terminals that are showed at the same time properly due to the amount of space left in it. Like in the following image

<img src="https://github.com/user-attachments/assets/f7cda146-0d94-4588-b5b9-634ceaa9aa8b" width=300></img>

It would be better to have them stacked on top of each other so that the user can see clearly the output of each of them when using vertical monitor, or just a window with smaller width. Like in the following image

<img width=300 src="https://github.com/user-attachments/assets/8c30aa5b-4eaa-43c0-93ea-748874177d5e"></img>


#closes https://github.com/akinsho/toggleterm.nvim/issues/616

# What does this PR do?

This PR solves the problem by adding a configuration setting that can be used to be define at which point the user would like to start stacking terminals on top of each other, instead of creating them next to each other when wanting to visualize more than one at the same time. The behavior described is better illustrated in the following video.

https://github.com/user-attachments/assets/4aaa5b05-17a0-44bd-ae4c-77ef6fd094e9

