### PR TITLE
fix: colorscheme on hidden terminal

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -351,7 +351,7 @@ local function setup_autocommands(_)
     callback = function()
       config.reset_highlights()
       for _, term in pairs(terms.get_all()) do
-        if api.nvim_win_is_valid(term.window) then
+        if term.window and api.nvim_win_is_valid(term.window) then
           api.nvim_win_call(term.window, function() ui.hl_term(term) end)
         end
       end


### PR DESCRIPTION
Fixes #435

I spawn a terminal at startup to improve initial performance. But if I run `colorscheme` before the terminal is shown, i.e. before it's attached to a window, an error is thrown because `term.window` is nil. I have fixed to verify `term.window` is not nil.

