### PR TITLE
feat: Add TermSend command

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ You can "send lines" to the toggled terminals with the following commands:
 - `:ToggleTermSendCurrentLine <T_ID>`: sends the whole line where you are standing with your cursor
 - `:ToggleTermSendVisualLines <T_ID>`: sends all the (whole) lines in your visual selection
 - `:ToggleTermSendVisualSelection <T_ID>`: sends only the visually selected text (this can be a block of text or a selection in a single line)
+- `:TermSend`: will prompt you to select the terminal to send the lines to and will infer what to send based on the current mode:
+  - `n`: the current line
+  - `V`: the visual line selection
+  - `v`: the visual selection
 
 (`<T_ID` is an optional terminal ID parameter, which defines where should we send the lines.
 If the parameter is not provided, then the default is the `first terminal`)

--- a/doc/toggleterm.txt
+++ b/doc/toggleterm.txt
@@ -307,6 +307,10 @@ You can "send lines" to the toggled terminals with the following commands:
 - `:ToggleTermSendCurrentLine <T_ID>`sends the whole line where you are standing with your cursor
 - `:ToggleTermSendVisualLines <T_ID>`sends all the (whole) lines in your visual selection
 - `:ToggleTermSendVisualSelection <T_ID>`sends only the visually selected text (this can be a block of text or a selection in a single line)
+- `:TermSend`: will prompt you to select the terminal to send the lines to and will infer what to send based on the current mode:
+  - `n`: the current line
+  - `V`: the visual line selection
+  - `v`: the visual selection
 
 (`<T_ID` is an optional terminal ID parameter, which defines where should we
 send the lines. If the parameter is not provided, then the default is the

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -579,6 +579,26 @@ function M.get_all(include_hidden)
   return result
 end
 
+-- Prompts to select an open terminal
+--
+-- It will short circuit to the given callback if there is only one terminal open
+--
+-- @param include_hidden boolean whether or not to include hidden terminals
+-- @param prompt string the prompt to display
+-- @param callback fun the function to call with the selected terminal
+function M.select_terminal(include_hidden, prompt, callback)
+  local terminals = terminals or M.get_all(include_hidden)
+  if #terminals == 0 then return utils.notify("No toggleterms are open yet", "info") end
+  if #terminals == 1 then return callback(terminals[1]) end
+  vim.ui.select(terminals, {
+    prompt = prompt,
+    format_item = function(term) return term.id .. ": " .. term:_display_name() end,
+  }, function(term)
+    if not term then return end
+    callback(term)
+  end)
+end
+
 if _G.IS_TEST then
   function M.__reset()
     for _, term in pairs(terminals) do


### PR DESCRIPTION
`TermSend` is a smart command that will prompt you to select the terminal to send the lines to and will infer what to send based on the current mode:

- `n`: the current line
- `V`: the visual line selection
- `v`: the visual selection

We've extracted the terminal selection logic into a new function `select_terminal_and_send_selection` and we've also added a short-circuit feature to it so that when only one terminal is open it's selected automatically.