### PR TITLE
fix: content shift after open the terminal

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -502,6 +502,7 @@ function Terminal:open(size, direction)
   ui.hl_term(self)
   -- NOTE: it is important that this function is called at this point. i.e. the buffer has been correctly assigned
   if self.on_open then self:on_open() end
+  vim.api.nvim_win_call(self.window, function() vim.cmd("normal! gg0") end)
 end
 
 ---Open if closed and close if opened


### PR DESCRIPTION
Previously, I discovered the problem of content shift and created [#650](https://github.com/akinsho/toggleterm.nvim/issues/650). Now I have found a relatively good solution. It should be executed after open the window. I think it should not be configured by the user in the `on_open` hook and should exist by default😊.

Then, #650 can closed
